### PR TITLE
Additional methods to be used in transformation templates. 

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
@@ -1146,6 +1146,32 @@ public class HL7MessageUtils {
 		HL7Message hl7Message = new HL7Message(message);
 		hl7Message.clearFieldFromAllSegments(segment, fieldIndex);			
 	}
+	
+	
+	/**
+	 * Clears all fields from a segment starting at the supplied startingFieldIndex in all matching segments.
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param startingFieldIndex
+	 */
+	public static void clearFieldsFrom(Message message, String segment, int startingFieldIndex) throws Exception {
+		clearFieldRange(message, segment, startingFieldIndex, -1);
+	}
+	
+	
+	/**
+	 * Clears all fields from the supplied startingFieldIndex to the endingFieldIndex in all matching segments.
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param startingFieldIndex
+	 * @param endingFieldIndex
+	 */
+	public static void clearFieldRange(Message message, String segment, int startingFieldIndex, int endingFieldIndex) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		hl7Message.clearFieldRange(segment, startingFieldIndex, endingFieldIndex);			
+	}
 
 	
 	/**

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -169,7 +169,7 @@ public class Field implements Serializable {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public Subfield getSubField(int subFieldIndex) {
+	public Subfield getSubField(int subFieldIndex) throws Exception {
 		return getSubField(0, subFieldIndex);
 	}
 	
@@ -180,7 +180,7 @@ public class Field implements Serializable {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public String getSubFieldValue(int subFieldIndex) {
+	public String getSubFieldValue(int subFieldIndex) throws Exception {
 		return getSubFieldValue(0, subFieldIndex);
 	}
 	
@@ -191,9 +191,13 @@ public class Field implements Serializable {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public Subfield getSubField(int repetition, int subFieldIndex) {
+	public Subfield getSubField(int repetition, int subFieldIndex) throws Exception {
+	
+		// If the subfield does not exist then add it.
 		if (subFieldIndex > getRepetitions().get(repetition).getSubFields().size()) {
-			return null;
+			addSubField("", subFieldIndex);
+			
+			return getSubField(subFieldIndex);
 		}
 		
 		return getRepetitions().get(repetition).getSubField(subFieldIndex);
@@ -206,17 +210,13 @@ public class Field implements Serializable {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public String getSubFieldValue(int repetition, int subFieldIndex) {
+	public String getSubFieldValue(int repetition, int subFieldIndex) throws Exception {
 		if (subFieldIndex > getRepetitions().get(repetition).getSubFields().size()) {
 			return "";
 		}
 		
 		Subfield subField = getRepetitions().get(repetition).getSubField(subFieldIndex);
-		
-		if (subField == null) {
-			return "";
-		}
-		
+				
 		return subField.value();			
 	}
 	
@@ -326,6 +326,19 @@ public class Field implements Serializable {
 		
 		fieldRepetition.addSubField(value, subFieldIndex);
 	}
+	
+	
+	/**
+	 * Adds a subfield at the supplied position.  This inserts a new subfield, it does not replace the value
+	 * of an existing subfield.  1st repetition only.
+	 * 
+	 * @param value
+	 * @param subFieldIndex
+	 * @throws Exception
+	 */
+	public void addSubField(String value, int subFieldIndex) throws Exception {
+		addSubField(value, 0, subFieldIndex);
+	}
 
 	
 	/**
@@ -349,6 +362,20 @@ public class Field implements Serializable {
 	
 	
 	/**
+	 * Adds a subfield at the supplied position.  This inserts a new subfield, it does not replace the value
+	 * of an existing subfield.  1st repetition only.
+	 * 
+	 * @param subField
+	 * @param repetition
+	 * @param subFieldIndex
+	 * @throws Exception
+	 */	
+	public void addSubField(Subfield subField, int subFieldIndex) throws Exception {
+		addSubField(subField, subFieldIndex);
+	}
+
+	
+	/**
 	 * Is this field empty?
 	 * 
 	 * @return
@@ -370,21 +397,10 @@ public class Field implements Serializable {
 	 * @param fieldIndex
 	 * @return
 	 */
-	public boolean isSubFieldEmpty(int subFieldIndex) {
+	public boolean isSubFieldEmpty(int subFieldIndex) throws Exception {
 		return isSubFieldEmpty(0, subFieldIndex);
 	}
-	
-	
-	/**
-	 * Checks to see if the sub field is exists.
-	 * 
-	 * @param fieldIndex
-	 * @return
-	 */
-	public boolean doesSubFieldExist(int subFieldIndex) {
-		return doesSubFieldExist(0, subFieldIndex);
-	}
-	
+
 	
 	/**
 	 * Checks to see if the sub field at the specified repetition is empty.  Either doesn't exist or is blank.
@@ -392,7 +408,7 @@ public class Field implements Serializable {
 	 * @param fieldIndex
 	 * @return
 	 */
-	public boolean isSubFieldEmpty(int repetition, int subFieldIndex) {
+	public boolean isSubFieldEmpty(int repetition, int subFieldIndex) throws Exception {
 		FieldRepetition fieldRepetition = getRepetition(repetition);
 		
 		if (fieldRepetition == null) {
@@ -400,30 +416,10 @@ public class Field implements Serializable {
 		}
 		
 		Subfield subField = fieldRepetition.getSubField(subFieldIndex);
-		
-		if (subField == null) {
-			return true;
-		}
-		
+				
 		return subField.isEmpty();
 	}
 	
-	
-	/**
-	 * Checks to see if the sub field at the specified repetition exists.
-	 * 
-	 * @param fieldIndex
-	 * @return
-	 */
-	public boolean doesSubFieldExist(int repetition, int subFieldIndex) {
-		FieldRepetition fieldRepetition = getRepetition(repetition);
-		
-		if (fieldRepetition == null) {
-			return true;
-		}
-		
-		return fieldRepetition.getSubField(subFieldIndex) != null;
-	}
 	
 	@Override
 	public int hashCode() {
@@ -495,5 +491,85 @@ public class Field implements Serializable {
 	 */
 	public List<Subfield>getSubFields() throws Exception {
 		return getSubFields(0);
+	}
+	
+	
+	/**
+	 * Clears all subFields from the startingSubFieldIndex in the supplied field repetition.
+	 * 
+	 * @param fieldRepetition
+	 * @param startingSubFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldsFrom(int fieldRepetition, int startingSubFieldIndex) throws Exception {
+		clearSubFieldRange(fieldRepetition, startingSubFieldIndex, -1);
+	}
+	
+	
+	/**
+	 * Clears all subFields from the startingSubFieldIndex in the 1st field repetition.
+	 * 
+	 * @param startingSubFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldsFrom(int startingSubFieldIndex) throws Exception {
+		clearSubFieldRange(0, startingSubFieldIndex, -1);
+	}
+
+	
+	/**
+	 * Clears all subFields from the startingSubFieldIndex in all field repetitions.
+	 * 
+	 * @param startingSubFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldsFromAllRepetitions(int startingSubFieldIndex) throws Exception {
+		for (FieldRepetition repetition : this.repetitions) {
+			repetition.clearSubFieldsFrom(startingSubFieldIndex);
+		}
+	}
+
+	
+	/**
+	 * Clears all subFields from the supplied startingFieldIndex to the endingFieldIndex in the supplied field repetition.
+	 * 
+	 * @param startingFieldIndex
+	 * @param endingFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldRange(int fieldRepetition, int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
+		FieldRepetition repetition = this.getRepetition(fieldRepetition);
+		
+		if (repetition == null) {
+			return;
+		}
+		
+		repetition.clearSubFieldRange(startingSubFieldIndex, endingSubFieldIndex);
+	}
+
+	
+	/**
+	 * Clears all subFields from the supplied startingFieldIndex to the endingFieldIndex in the 1st field repetition.
+	 * 
+	 * @param startingSubFieldIndex
+	 * @param endingSubFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldRange(int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
+		clearSubFieldRange(0, startingSubFieldIndex, endingSubFieldIndex);
+	}
+
+	
+	/**
+	 * Clears all subFields from the supplied startingFieldIndex to the endingFieldIndex in all field repetitions.
+	 * 
+	 * @param startingSubFieldIndex
+	 * @param endingSubFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldRangeAllRepetitions(int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
+		for (FieldRepetition fieldRepetition : this.repetitions) {
+			fieldRepetition.clearSubFieldRange(startingSubFieldIndex, endingSubFieldIndex);
+		}
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
@@ -60,9 +60,11 @@ public class FieldRepetition implements Serializable  {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public Subfield getSubField(int subFieldIndex) {
+	public Subfield getSubField(int subFieldIndex) throws Exception {
+		
+		// If the subfield doesn't exist then add it.
 		if (subFieldIndex > subFields.size()) {
-			return null;
+			addSubField("", --subFieldIndex);
 		}
 		
 		return subFields.get(--subFieldIndex);
@@ -75,13 +77,9 @@ public class FieldRepetition implements Serializable  {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public String getSubFieldValue(int subFieldIndex) {
+	public String getSubFieldValue(int subFieldIndex) throws Exception {
 		Subfield subField = getSubField(subFieldIndex);
-		
-		if (subField == null) {
-			return "";
-		}
-		
+				
 		return subField.value();
 	}
 	
@@ -115,11 +113,7 @@ public class FieldRepetition implements Serializable  {
 	 */
 	public void clearSubField(int subFieldIndex) throws Exception {	
 		Subfield subField = getSubField(subFieldIndex);
-		
-		if (subField == null) {
-			return;
-		}
-		
+				
 		subField.clear();
 	}
 
@@ -184,16 +178,12 @@ public class FieldRepetition implements Serializable  {
 	public void setValue(String value, int subFieldIndex) throws Exception {
 		Subfield subField = getSubField(subFieldIndex);
 		
-		if (subField == null) {
-			addSubField(value, subFieldIndex);
-		} else {
-			subField.setValue(value);
-		}
+		subField.setValue(value);
 	}
 	
 	
 	/**
-	 * Adds a field at the specified index.  This adds a new sub field it does not update an existing one.
+	 * Adds a field at the specified index.  This adds a new sub field, it does not update an existing one.
 	 * 
 	 * @param value
 	 * @param index
@@ -226,26 +216,12 @@ public class FieldRepetition implements Serializable  {
 	 * @param fieldIndex
 	 * @return
 	 */
-	public boolean isSubFieldEmpty(int subFieldIndex) {
+	public boolean isSubFieldEmpty(int subFieldIndex) throws Exception {
 		Subfield subField =  getSubField(subFieldIndex);
-		
-		if (subField == null) {
-			return true;
-		}
-		
+				
 		return subField.isEmpty();
 	}
 	
-	
-	/**
-	 * Checks to see if the sub field exists.
-	 * 
-	 * @param subFieldIndex
-	 * @return
-	 */
-	public boolean doesSubFieldExist(int subFieldIndex) {
-		return getSubField(subFieldIndex) != null;
-	}
 	
 	@Override
 	public int hashCode() {
@@ -256,5 +232,39 @@ public class FieldRepetition implements Serializable  {
 	@Override
 	public boolean equals(Object obj) {	
 		return Objects.equals(this.toString(), obj.toString());
+	}
+	
+	
+	/**
+	 * Clears all subFields from the supplied startingFieldIndex.
+	 * 
+	 * @param startingSubFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldsFrom(int startingSubFieldIndex) throws Exception {
+		clearSubFieldRange(startingSubFieldIndex, -1);
+	}
+	
+	
+	/**
+	 * Clears all subFields from the supplied startingFieldIndex to the endingFieldIndex.
+	 * 
+	 * @param startingFieldIndex
+	 * @param endingFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldRange(int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
+			
+		if (endingSubFieldIndex == -1) {
+			endingSubFieldIndex = getSubFields().size();
+		} 
+		
+		for (int i = startingSubFieldIndex; i <= endingSubFieldIndex; i++) {
+			Subfield subField = getSubField(i);
+			
+			if (subField != null) {
+				subField.clear();
+			}
+		}
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -432,4 +432,30 @@ public class HL7Message implements Serializable   {
 			}
 		}
 	}
+
+	
+	/**
+	 * Clears all fields from a segment starting at the supplied startingFieldIndex in all matching segments.
+	 * 
+	 * @param segment
+	 * @param startingFieldIndex
+	 */
+	public void clearFieldsFrom(String segmentName, int startingFieldIndex) throws Exception {
+		clearFieldRange(segmentName, startingFieldIndex, -1);
+	}
+
+	
+	/**
+	 * Clears all fields from the supplied startingFieldIndex to the endingFieldIndex in all matching segments.
+	 * 
+	 * @param segment
+	 * @param startingFieldIndex
+	 * @param endingFieldIndex
+	 */
+	public void clearFieldRange(String segmentName, int startingFieldIndex, int endingFieldIndex) throws Exception {
+
+		for (Segment segment : getSegments(segmentName)) {
+			segment.clearFieldRange(startingFieldIndex, endingFieldIndex);
+		}
+	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -86,9 +86,9 @@ public class Segment implements Serializable {
 	 * @param fieldIndex
 	 * @return
 	 */
-	public Field getField(int fieldIndex) {
+	public Field getField(int fieldIndex) throws Exception {
 		if (fieldIndex >= fields.size()) {
-			return null;
+			addField("", fieldIndex);
 		}
 		
 		return fields.get(fieldIndex);
@@ -102,13 +102,9 @@ public class Segment implements Serializable {
 	 * @param repetition
 	 * @return
 	 */
-	public FieldRepetition getFieldRepetition(int fieldIndex, int repetition) {
+	public FieldRepetition getFieldRepetition(int fieldIndex, int repetition) throws Exception {
 		Field field = getField(fieldIndex);
-		
-		if (field == null) {
-			return null;
-		}
-		
+				
 		return field.getRepetition(repetition);
 	}
 
@@ -200,11 +196,7 @@ public class Segment implements Serializable {
 	 */
 	public void clearField(int fieldIndex, int repetition) throws Exception {
 		Field field = this.getField(fieldIndex);
-		
-		if (field == null) {
-			return;
-		}
-		
+			
 		field.clear(repetition);
 	}
 	
@@ -217,11 +209,7 @@ public class Segment implements Serializable {
 	 */
 	public void clearAllFieldRepetitions(int fieldIndex) throws Exception {
 		Field field = this.getField(fieldIndex);
-		
-		if (field == null) {
-			return;
-		}
-		
+				
 		field.clearAllRepetitions();
 	}
 
@@ -235,11 +223,7 @@ public class Segment implements Serializable {
 	 */
 	public void clearSubField(int fieldIndex, int repetition, int subFieldIndex) throws Exception {
 		Field field = this.getField(fieldIndex);
-		
-		if (field == null) {
-			return;
-		}
-		
+				
 		field.clearSubField(subFieldIndex, repetition);
 	}
 
@@ -265,11 +249,7 @@ public class Segment implements Serializable {
 	 */
 	public void clearSubFieldFromAllFieldRepetitions(int fieldIndex, int subFieldIndex) throws Exception {
 		Field field = this.getField(fieldIndex);
-		
-		if (field == null) {
-			return;
-		}
-		
+				
 		field.clearSubFieldFromAllFieldRepetitions(subFieldIndex);		
 	}
 
@@ -282,7 +262,7 @@ public class Segment implements Serializable {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public Subfield getSubField(int fieldIndex, int repetition, int subFieldIndex) {
+	public Subfield getSubField(int fieldIndex, int repetition, int subFieldIndex) throws Exception {
 		FieldRepetition fieldRepetition = getFieldRepetition(subFieldIndex, repetition);
 		
 		if (fieldRepetition == null) {
@@ -301,7 +281,7 @@ public class Segment implements Serializable {
 	 * @param subFieldIndex
 	 * @return
 	 */
-	public Subfield getSubField(int fieldIndex, int subFieldIndex) {
+	public Subfield getSubField(int fieldIndex, int subFieldIndex) throws Exception {
 		return getSubField(fieldIndex, 0, subFieldIndex);
 	}
 
@@ -322,53 +302,10 @@ public class Segment implements Serializable {
 	 * @param fieldIndex
 	 * @return
 	 */
-	public boolean isFieldEmpty(int fieldIndex) {
+	public boolean isFieldEmpty(int fieldIndex) throws Exception {
 		Field field =  getField(fieldIndex);
-		
-		if (field == null) {
-			return true;
-		}
-		
+						
 		return field.isEmpty();
-	}
-
-	
-	/**
-	 * Checks to see if the field is exists.
-	 * 
-	 * @param fieldIndex
-	 * @return
-	 */
-	public boolean doesFieldExist(int fieldIndex) {
-		return getField(fieldIndex) != null;
-	}
-
-	
-	/**
-	 * Checks to see if the sub field is exists in the supplied repetition of the field.
-	 * 
-	 * @param fieldIndex
-	 * @return
-	 */
-	public boolean doesSubFieldExist(int fieldIndex, int repetition, int subFieldIndex) {
-		Field field = getField(fieldIndex);
-		
-		if (field == null) {
-			return false;
-		}
-		
-		return field.doesSubFieldExist(repetition, subFieldIndex);	
-	}
-
-	
-	/**
-	 * Checks to see if the sub field exists in the 1st repetition of the field.
-	 * 
-	 * @param fieldIndex
-	 * @return
-	 */
-	public boolean doesSubFieldExist(int fieldIndex, int subFieldIndex) {
-		return doesSubFieldExist(fieldIndex, 0, subFieldIndex);
 	}
 
 	
@@ -402,13 +339,9 @@ public class Segment implements Serializable {
 	 * @param repetition
 	 * @return
 	 */
-	public String getFieldValue(int fieldIndex, int repetition) {
+	public String getFieldValue(int fieldIndex, int repetition) throws Exception {
 		Field field = getField(fieldIndex);
-		
-		if (field == null) {
-			return "";
-		}
-		
+				
 		FieldRepetition fieldRepetition = field.getRepetition(repetition);
 		
 		if (fieldRepetition == null) {
@@ -431,10 +364,6 @@ public class Segment implements Serializable {
 	public void combinedSubFields(int fieldIndex, int fieldRepetition, String separator, boolean allowSequentialSeparators) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		if (field == null) {
-			return;
-		}		
-		
 		field.combinedSubFields(fieldRepetition, separator, allowSequentialSeparators);
 	}
 	
@@ -449,10 +378,6 @@ public class Segment implements Serializable {
 	public void combinedSubFields(int fieldIndex, String separator, boolean allowSequentialSeparators) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		if (field == null) {
-			return;
-		}		
-		
 		field.combinedSubFields(0, separator, allowSequentialSeparators);
 	}
 	
@@ -463,7 +388,7 @@ public class Segment implements Serializable {
 	 * @param fieldIndex
 	 * @return
 	 */
-	public String getFieldValue(int fieldIndex) {
+	public String getFieldValue(int fieldIndex) throws Exception {
 		return getFieldValue(fieldIndex, 0);
 	}
 
@@ -477,5 +402,37 @@ public class Segment implements Serializable {
 	@Override
 	public boolean equals(Object obj) {	
 		return Objects.equals(this.toString(), obj.toString());
+	}
+	
+	
+	/**
+	 * Clears all fields from this segment starting at the supplied startingFieldIndex.
+	 * 
+	 * @param startingFieldIndex
+	 */
+	public void clearFieldsFrom(int startingFieldIndex) throws Exception {
+		clearFieldRange(startingFieldIndex, -1);
+	}
+	
+	
+	/**
+	 * Clears all fields from the supplied startingFieldIndex to the endingFieldIndex in this segment.
+	 * 
+	 * @param startingFieldIndex
+	 * @param endingFieldIndex
+	 * @throws Exception
+	 */
+	public void clearFieldRange(int startingFieldIndex, int endingFieldIndex) throws Exception {
+		if (endingFieldIndex == -1) {
+			endingFieldIndex = getFields().size();
+		}			
+		
+		for (int i = startingFieldIndex; i < endingFieldIndex; i++) {
+			Field field = getField(i);
+			
+			if (field != null) {
+				field.clear();
+			}
+		}
 	}
 }


### PR DESCRIPTION
Due to required transformation rules changes I have done the following.  Everything here could have been done in Freemarker templates but this will enable these methods to be reused and simplify the templates.

1) Create some methods to clear fields from a segment.  A starting index or a range can be provided.  The existing fields are not touched.

2) Create some methods to clear subFields from a field.  A starting index or a range can be provided.  A repetition can also be specified.   the existing subFields are not touched.

3) Have the getField method in the Segment class add an empty field to the segment.

4) Have the getSubField method in the the FieldRepetition class add an empty SubField.

4 and 5 above will help prevent NPEs and make the transformation templates simpler as the developer doesn't need to keep checking if a field or subField exists before setting a value.