### PR TITLE
Bug/252255 update for v2.3.1

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
@@ -54,8 +54,22 @@ public class HL7MessageUtils {
             
             return inputMessage;
 		}
-	}
+	} 
+
 	
+	/**
+	 * Returns a pegacorn HL7 message object from message.
+	 * 
+	 * @param message
+	 * @return
+	 * @throws Exception
+	 */
+	public static HL7Message getHL7Message(Message message) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		
+		return hl7Message;
+	}
+
 	
 	/**
 	 * 

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -416,6 +416,22 @@ public class Segment implements Serializable {
 	
 	
 	/**
+	 * Moves a field value from one field to another
+	 * 
+	 * @param fromFieldIndex
+	 * @param toFieldIndex
+	 * @throws Exception
+	 */
+	public void moveField(int fromFieldIndex, int toFieldIndex) throws Exception {
+		Field fromField = this.getField(fromFieldIndex);
+		Field toField = this.getField(toFieldIndex);
+		
+		toField.setValue(fromField.value());
+		fromField.clear();
+	}
+	
+	
+	/**
 	 * Clears all fields from the supplied startingFieldIndex to the endingFieldIndex in this segment.
 	 * 
 	 * @param startingFieldIndex


### PR DESCRIPTION
Add a non terser move method and a method to return the HL7Message.  The non terser method will enable the same template to handle any 2.x version.