### PR TITLE
Additional transformation methods to be used in transformation templates

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
@@ -1065,6 +1065,22 @@ public class HL7MessageUtils {
 	
 	
 	/**
+	 * Inserts a segment at the target index which has identical content to the source segment.
+	 * 
+	 * @param message
+	 * @param sourceIndex
+	 * @param targetIndex
+	 * @throws Exception
+	 */
+	public static Segment insertSegment(Message message, Segment source, int targetIndex) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		
+		return hl7Message.insertSegment(source, targetIndex);
+	}
+	
+	
+	
+	/**
 	 * Moves a segment from one position to another.
 	 * 
 	 * @param message
@@ -1203,5 +1219,122 @@ public class HL7MessageUtils {
 	public static void setSubFieldInAllSegments(Message message, String segment, int fieldIndex, int subFieldIndex, String value) throws Exception {
 		HL7Message hl7Message = new HL7Message(message);
 		hl7Message.setSubFieldInAllSegments(segment, fieldIndex, subFieldIndex, value);			
+	}
+
+	
+	/**
+	 * Returns the number of segment groups for the supplied segment
+	 * 
+	 * @param message
+	 * @param segment
+	 * @return
+	 */
+	public static Integer getNumberOfSegmentGroups(Message message, String segment) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		
+		return hl7Message.getNumberOfSegmentGroups(segment);
+	}
+
+	
+	/**
+	 * Returns the start index of the segment group.
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param groupNumber
+	 * @return
+	 */
+	public static Integer getStartIndexOfSegmentGroup(Message message, String segment, int groupNumber) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);	
+		
+		return hl7Message.getStartIndexOfSegmentGroup(segment, groupNumber);
+	}
+
+	
+	/**
+	 * Returns the end index of the segment group.
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param groupNumber
+	 * @return
+	 */
+	public static Integer getEndIndexOfSegmentGroup(Message message, String segment, int groupNumber) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);	
+		
+		return hl7Message.getEndIndexOfSegmentGroup(segment, groupNumber);
+	}
+
+	
+	/**
+	 * Returns all the segments within a group.
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param groupNumber
+	 * @return
+	 */
+	public static List<Segment> getSegmentsWithinGroup(Message message, String segment, int groupNumber) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);	
+		
+		return hl7Message.getSegmentsWithinGroup(segment, groupNumber);
+	}
+
+	
+	/**
+	 * Returns an array of indexes which are the start indexes of each segment group.
+	 * 
+	 * @param segmentName
+	 * @return
+	 */
+	public static List<Integer> getStartIndexesOfSegmentGroups(Message message, String segment) throws Exception {	
+		HL7Message hl7Message = new HL7Message(message);	
+		
+		return hl7Message.getStartIndexesOfSegmentGroups(segment);		
+	}
+	
+	
+	/**
+	 * Appends a segment to the end of a group
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param groupNumber
+	 */
+	public static Segment appendSegmentToGroup(Message message, String segment, int groupNumber) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);	
+		
+		return hl7Message.appendSegmentToGroup(segment, groupNumber);		
+	}
+
+	
+	/**
+	 * Does the supplied value appear in the specified field of any matching segment.  All field repetitions are checked.
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param value
+	 * @return
+	 */
+	public static boolean doesFieldContainValue(Message message, String segment, int fieldIndex, String value) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		
+		return hl7Message.doesFieldContainValue(segment, fieldIndex, value);
+	}
+
+	
+	/**
+	 * Does the supplied value appear in the specified subField of any matching segment.  All field repetitions are checked.
+	 * 
+	 * @param message
+	 * @param segment
+	 * @param fieldIndex
+	 * @param value
+	 * @return
+	 */
+	public static boolean doesSubFieldContainValue(Message message, String segment, int fieldIndex, int subFieldIndex, String value) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		
+		return hl7Message.doesSubFieldContainValue(segment, fieldIndex, subFieldIndex, value);
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -572,4 +572,41 @@ public class Field implements Serializable {
 			fieldRepetition.clearSubFieldRange(startingSubFieldIndex, endingSubFieldIndex);
 		}
 	}
+
+	
+	/**
+	 * 
+	 * 
+	 * @param value
+	 * @return
+	 */
+	public boolean doesFieldContainValue(String value) {
+		for (FieldRepetition fieldRepetition : this.repetitions) {
+			if (fieldRepetition.value().contains(value)) {
+				return true;
+			}
+		}
+		
+		return false;
+	}
+
+	
+	/**
+	 * 
+	 * 
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public boolean doesSubFieldContainValue(int subFieldIndex, String value) throws Exception {
+		for (FieldRepetition fieldRepetition : this.repetitions) {
+			if (fieldRepetition.getSubField(subFieldIndex).value().contains(value)) {
+				return true;
+			}
+		}
+		
+		return false;		
+		
+	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
@@ -33,7 +33,7 @@ public class FieldRepetition implements Serializable  {
 		}
 				
 		for (String value : splitSubFieldRepetitions) {
-			Subfield subField = new Subfield(value, this);
+			Subfield subField = new Subfield(value, true, this);
 			subFields.add(subField);
 		}				
 	}
@@ -136,7 +136,7 @@ public class FieldRepetition implements Serializable  {
 			int sizeDifference = index - getSubFields().size();
 			
 			for (int i = 0; i < sizeDifference; i++) {
-				getSubFields().add(new Subfield("", this));
+				getSubFields().add(new Subfield("", true, this));
 			}
 		}
 		
@@ -160,7 +160,7 @@ public class FieldRepetition implements Serializable  {
 		splitSubFieldRepetitions = value.split("\\^");
 			
 		for (String fieldRepetitonValue : splitSubFieldRepetitions) {
-			Subfield subField = new Subfield(fieldRepetitonValue, this);
+			Subfield subField = new Subfield(fieldRepetitonValue, true, this);
 			subFields.add(subField);
 		}	
 		
@@ -190,7 +190,7 @@ public class FieldRepetition implements Serializable  {
 	 * @throws Exception
 	 */
 	public void addSubField(String value, int index) throws Exception {
-		addSubField(new Subfield(value, this),index);
+		addSubField(new Subfield(value, true, this),index);
 	}
 	
 	

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -451,4 +451,49 @@ public class Segment implements Serializable {
 			}
 		}
 	}
+
+	
+	/**
+	 * Does any repetition of the field in this segment contain the supplied value.
+	 * 
+	 * @param fieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public boolean doesFieldContainValue(int fieldIndex, String value) throws Exception {
+		Field field = getField(fieldIndex);
+		
+		return field.doesFieldContainValue(value);
+	}
+
+	
+	public boolean doesSubFieldContainValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+		Field field = getField(fieldIndex);
+		
+		return field.doesSubFieldContainValue(subFieldIndex, value);
+	}
+	
+	
+	/**
+	 * Sets a segment value.
+	 * 
+	 * @param value
+	 * @param clearExistingContent - if true the field value becomes the only value in this field.  All other repetitions are cleared.
+	 * @throws Exception
+	 */
+	public void setValue(String value) throws Exception {
+		fields.clear();
+
+		String[] splitFields = null;
+		
+		splitFields = value.split("\\|");
+		
+		for (String fieldValue : splitFields) {
+			Field field = new Field(fieldValue, true, this);
+			fields.add(field);
+		}
+		
+		this.getMessage().refreshSourceHL7Message();
+	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/SubSubfield.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/SubSubfield.java
@@ -1,0 +1,71 @@
+package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transformation.model;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * A sub-subfield.  Subfields are delimited by & within a field.
+ * 
+ * @author Bendan_Douglas
+ *
+ */
+public class SubSubfield implements Serializable {
+	private static final long serialVersionUID = -8174677055244513493L;
+
+	private String value;
+	
+	private Subfield subField = null;
+	
+	public SubSubfield(String value, Subfield subField) {
+		this.value = value;
+		this.subField = subField;
+	}
+
+	public String value() {
+		return value;
+	}
+
+	public void setValue(String value) throws Exception {
+		this.value = value;
+		
+		this.subField.geFieldRepetition().getField().getSegment().getMessage().refreshSourceHL7Message();
+	}
+	
+	@Override
+	public String toString() {
+		return value;
+	}
+	
+	
+	public void clear() throws Exception {
+		setValue("");
+	}
+	
+	
+    public Subfield geSubField() {
+		return subField;
+	}
+	
+	
+	/**
+	 * Is this subfield empty?
+	 * 
+	 * @return
+	 */
+	public boolean isEmpty() {
+		return StringUtils.isBlank(toString());
+	}
+	
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(this.toString());
+	}
+
+
+	@Override
+	public boolean equals(Object obj) {	
+		return Objects.equals(this.toString(), obj.toString());
+	}
+}


### PR DESCRIPTION
1) Add additional methods for an NCSR transformation.  These can be reused by other transformations.

2) Support sub-subfields.  This is required by NCSR.

The new group transformation methods were going to be used for NCSR but they are no longer needed but can stay so they can be used in the future.  There are methods to get the segments within a group, append a segment to the end of a group, get the start and end indexes etc.