### PR TITLE
Feature/254018 additional methods remove field repetitions

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/HL7MessageUtils.java
@@ -1337,4 +1337,34 @@ public class HL7MessageUtils {
 		
 		return hl7Message.doesSubFieldContainValue(segment, fieldIndex, subFieldIndex, value);
 	}
+	
+	
+	/**
+	 * Removes a field repetition where the matchValue matches the subField value.
+	 * 
+	 * @param message
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 */
+	public static void removeMatchingFieldRepetitions(Message message, String segment, int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		
+		hl7Message.removeMatchingFieldRepetitions(segment, fieldIndex, subFieldIndex, matchValue);		
+	}
+	
+	
+	/**
+	 * Removes a field repetition where the matchValue does not match the subField value.
+	 * 
+	 * @param message
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 */
+	public static void removeNotMatchingFieldRepetitions(Message message, String segment, int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+		HL7Message hl7Message = new HL7Message(message);
+		
+		hl7Message.removeNotMatchingFieldRepetitions(segment, fieldIndex, subFieldIndex, matchValue);	
+	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -627,19 +627,44 @@ public class Field implements Serializable {
 		
 		return false;		
 	}
-
+	
 	
 	/**
-	 * Removes empty repetitions from this field.
+	 * Removes a field repetition where the matchValue matches the subField value.
+	 * 
+	 * @param subFieldIndex
+	 * @param matchValue
 	 */
-	public void removeEmptyRepetitions() throws Exception {
-
-		Iterator<FieldRepetition> i = repetitions.iterator();
-		while (i.hasNext()) {
-			FieldRepetition repetition = i.next();
+	public void removeMatchingFieldRepetitions(int subFieldIndex, String matchValue) throws Exception {
+		Iterator<FieldRepetition>repetitionIterator = repetitions.iterator();
+		
+		while (repetitionIterator.hasNext()) {
+			FieldRepetition repetition = repetitionIterator.next();
 			
-			if (repetition.value().isEmpty()) {
-				i.remove();
+			if (repetition.getSubField(subFieldIndex).value().equals(matchValue)) {
+				repetitionIterator.remove();
+			}
+		}
+		
+		this.getSegment().getMessage().refreshSourceHL7Message();
+	}
+
+
+	/**
+	 * Removes a field repetition where the matchValue does not match the subField value.
+	 * 
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeNotMatchingFieldRepetitions(int subFieldIndex, String matchValue) throws Exception {
+		Iterator<FieldRepetition>repetitionIterator = repetitions.iterator();
+		
+		while (repetitionIterator.hasNext()) {
+			FieldRepetition repetition = repetitionIterator.next();
+			
+			if (!repetition.getSubField(subFieldIndex).value().equals(matchValue)) {
+				repetitionIterator.remove();
 			}
 		}
 		

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -2,6 +2,7 @@ package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transfo
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -48,7 +49,7 @@ public class Field implements Serializable {
 	}
 	
 	
-	public String toString() {	
+	public String toString() {		
 		return repetitions.stream().map(FieldRepetition::toString).collect(Collectors.joining("~"));
 	}
 
@@ -102,12 +103,30 @@ public class Field implements Serializable {
 	
 	
 	/**
+	 * Removes a repetition of the field.
+	 * 
+	 * @param repetition
+	 */
+	public void removeRepetition(FieldRepetition repetition) throws Exception {		
+		repetitions.remove(repetition);
+		
+		this.segment.getMessage().refreshSourceHL7Message();
+	}
+
+	
+	/**
 	 * Adds a repetition to this field.
 	 * 
 	 * @param fieldRepetition
 	 */
 	public void addRepetition(FieldRepetition fieldRepetition) throws Exception {
-		getRepetitions().add(fieldRepetition);
+		
+		// if the 1st repetition is empty then replace, otherwise add a new repetition to the end.
+		if (!this.value().isEmpty() ) {
+			getRepetitions().add(fieldRepetition);
+		} else {
+			getRepetitions().add(0, fieldRepetition);
+		}
 		
 		this.segment.getMessage().refreshSourceHL7Message();
 	}
@@ -607,6 +626,23 @@ public class Field implements Serializable {
 		}
 		
 		return false;		
+	}
+
+	
+	/**
+	 * Removes empty repetitions from this field.
+	 */
+	public void removeEmptyRepetitions() throws Exception {
+
+		Iterator<FieldRepetition> i = repetitions.iterator();
+		while (i.hasNext()) {
+			FieldRepetition repetition = i.next();
+			
+			if (repetition.value().isEmpty()) {
+				i.remove();
+			}
+		}
 		
+		this.getSegment().getMessage().refreshSourceHL7Message();
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -652,4 +652,34 @@ public class HL7Message implements Serializable   {
 		
 		return false;
 	}
+
+	
+	/**
+	 * Removes a field repetition where the matchValue matches the subField value.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @return
+	 */
+	public void removeMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+		for (Segment segment : this.getSegments(segmentName)) {
+			segment.removeMatchingFieldRepetitions(fieldIndex, subFieldIndex, matchValue);
+		}
+	}
+
+	
+	/**
+	 * Removes a field repetition where the matchValue does not match the subField value.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @return
+	 */
+	public void removeNotMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+		for (Segment segment : this.getSegments(segmentName)) {
+			segment.removeNotMatchingFieldRepetitions(fieldIndex, subFieldIndex, matchValue);
+		}
+	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -2,6 +2,7 @@ package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transfo
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -495,5 +496,34 @@ public class Segment implements Serializable {
 		}
 		
 		this.getMessage().refreshSourceHL7Message();
+	}
+
+
+	/**
+	 * Removes a field repetition where the matchValue matches the subField value.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeMatchingFieldRepetitions(int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+		Field field = this.getField(fieldIndex);
+		
+		field.removeMatchingFieldRepetitions(subFieldIndex, matchValue);	
+	}
+
+
+	/**
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeNotMatchingFieldRepetitions(int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+		Field field = this.getField(fieldIndex);
+		
+		field.removeNotMatchingFieldRepetitions(subFieldIndex, matchValue);
+		
 	}
 }


### PR DESCRIPTION
I added some methods to remove field repetitions.  It is much easier to add this as a common reusable method to be called from the transformation templates than to implement in freemarker.  