### PR TITLE
Additional methods to be used in transformations template

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -15,7 +15,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author Brendan Douglas
  *
  */
-public class Field implements Serializable {
+public class Field extends MessageComponent implements Serializable {
 	private static final long serialVersionUID = 3815655672813186758L;
 
 	private List<FieldRepetition> repetitions = new ArrayList<>();
@@ -144,7 +144,7 @@ public class Field implements Serializable {
 			getRepetitions().add(0, fieldRepetition);
 		}
 	}
-	
+
 	
 	/**
 	 * Adds a repetition to this field.
@@ -152,9 +152,23 @@ public class Field implements Serializable {
 	 * @param value
 	 * @throws Exception
 	 */
-	public void addRepetition(String value) throws Exception {
+	public FieldRepetition addRepetition(String value) throws Exception {
 		FieldRepetition fieldRepetition = new FieldRepetition(value, false, this);
 		this.addRepetition(fieldRepetition);
+		
+		return fieldRepetition;
+	}
+
+	
+	/**
+	 * Adds an empty repetition.
+	 * 
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public FieldRepetition addEmptyRepetition() throws Exception {
+		return addRepetition("");
 	}
 
 	
@@ -695,4 +709,26 @@ public class Field implements Serializable {
 			}
 		}
 	}
+
+
+	/**
+	 * Returns a repetition of this field containing the supplied value at the supplied sub field index.
+	 * 
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public FieldRepetition getRepetitionContainingValue(int subFieldIndex, String value) throws Exception {
+		for (FieldRepetition repetition : getRepetitions()) {
+			Subfield subField = repetition.getSubField(subFieldIndex);
+			
+			if (subField.value().equals(value)) {
+				return repetition;
+			}
+		}
+		
+		return null;
+	}
+
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -51,6 +51,7 @@ public class Field extends MessageComponent implements Serializable {
 	}
 	
 	
+	@Override
 	public String toString() {		
 		String originalValue = repetitions.stream().map(FieldRepetition::toString).collect(Collectors.joining("~"));
 		
@@ -141,7 +142,7 @@ public class Field extends MessageComponent implements Serializable {
 		if (!this.value().isEmpty() ) {
 			getRepetitions().add(fieldRepetition);
 		} else {
-			getRepetitions().add(0, fieldRepetition);
+			getRepetitions().set(0, fieldRepetition);
 		}
 	}
 
@@ -179,6 +180,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param clearExistingContent - if true the field value becomes the only value in this field.  All other repetitions are cleared.
 	 * @throws Exception
 	 */
+	@Override
 	public void setValue(String value) throws Exception {
 		repetitions.clear();
 
@@ -266,6 +268,7 @@ public class Field extends MessageComponent implements Serializable {
 	}
 	
 	
+	@Override
 	public String value() {
 		return toString();
 	}
@@ -274,6 +277,7 @@ public class Field extends MessageComponent implements Serializable {
 	/**
 	 * Clears the entire field, including all repetitions.
 	 */
+	@Override
 	public void clear() throws Exception {
 		setValue("");
 	}

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
@@ -14,7 +14,7 @@ import ca.uhn.hl7v2.HL7Exception;
  * @author Brendan_Douglas
  *
  */
-public class FieldRepetition implements Serializable  {
+public class FieldRepetition extends MessageComponent implements Serializable  {
 	private static final long serialVersionUID = -861537957069177073L;
 	
 	private List<Subfield>subFields = new ArrayList<>();

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -174,6 +174,14 @@ public class HL7Message implements Serializable   {
 	}
 	
 	
+	public void removeSegments(Segment[] segments) throws Exception {	
+		
+		for (Segment segment : segments) {
+			removeSegment(segment);
+		}
+	}
+	
+	
 	/**
 	 * Removes the 1st occurrence of a segment.
 	 * 
@@ -689,6 +697,71 @@ public class HL7Message implements Serializable   {
 
 	
 	/**
+	 * Gets a Field repetition containing the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public FieldRepetition getFieldRepetitionContainingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+		for (Segment segment : this.getSegments(segmentName)) {			
+			FieldRepetition fieldRepetition =  segment.getFieldRepetitionContainingValue(fieldIndex, subFieldIndex, value);
+			
+			if (fieldRepetition != null) {
+				return fieldRepetition;
+			}
+		}
+		
+		return null;
+	}
+	
+	
+	
+	/**
+	 * Gets a Field repetition containing the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public Field getFieldContainingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+		for (Segment segment : this.getSegments(segmentName)) {			
+			Field field =  segment.getFieldContainingValue(fieldIndex, subFieldIndex, value);
+			
+			if (field != null) {
+				return field;
+			}
+		}
+		
+		return null;
+	}
+
+	
+	/**
+	 * Gets a Segment containing the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public Segment getSegmentContainingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+		for (Segment segment : this.getSegments(segmentName)) {			
+			if (segment.doesSubFieldContainValue(fieldIndex, subFieldIndex, value)) {
+				return segment;
+			}
+		}
+		
+		return null;
+	}
+
+	
+	/**
 	 * Removes a field repetition where the matchValue matches the subField value.
 	 * 
 	 * @param fieldIndex
@@ -785,7 +858,8 @@ public class HL7Message implements Serializable   {
 		
 		
 		if (messageType.endsWith("_*")) {	
-			return type.substring(0, 3).equals(messageType.substring(0, 3));
+			boolean val =  type.substring(0, 3).equals(messageType.substring(0, 3));
+			return val;
 		}
 		
 		return type.equals(messageType);

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MSHSegment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MSHSegment.java
@@ -1,0 +1,65 @@
+package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transformation.model;
+
+import java.io.Serializable;
+import java.util.stream.Collectors;
+
+/**
+ * An MSH segment.
+ * 
+ * @author Brendan Douglas
+ *
+ */
+public class MSHSegment extends Segment implements Serializable {
+	private static final long serialVersionUID = -8797054428191615724L;
+		
+	public MSHSegment(String segment, HL7Message message) {
+		this.message = message;
+		
+		String[] splitSegmentFields = segment.split("\\|");
+				
+		fields.add(new Field(splitSegmentFields[0], true, this));
+		
+		int startIndex = 1;
+			
+		startIndex = 2;
+		fields.add(new Field("|", false, this));
+		fields.add(new Field(splitSegmentFields[1],false, this));
+
+		
+		for (int i = startIndex; i < splitSegmentFields.length; i++) {
+			String value = splitSegmentFields[i];
+			Field field = new Field(value, true, this);
+			fields.add(field);
+		}
+	}
+	
+	
+	@Override
+	public String toString() {	
+		String segment = fields.stream().skip(3).map(Field::toString).collect(Collectors.joining("|"));
+		
+		return "MSH|^~\\&|"+segment;
+	}
+	
+	
+	/**
+	 * Returns the type of the message. MSH-9.
+	 * 
+	 * @return
+	 * @throws Exception
+	 */
+	public Field getMessageTypeField() throws Exception {
+		return this.getField(9);
+	}
+	
+	
+	/**
+	 * Changes the version of this message.
+	 * 
+	 * @param newVersion
+	 * @throws Exception
+	 */
+	public void changeMessageVersion(String newVersion) throws Exception {
+		getField(12).setValue(newVersion);
+	}
+}

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MessageComponent.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MessageComponent.java
@@ -1,0 +1,56 @@
+package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transformation.model;
+
+/**
+ * A message component.
+ * 
+ * @author Brendan Douglas
+ *
+ */
+public abstract class MessageComponent {
+	
+	/**
+	 * Gets the components value.
+	 * 
+	 * @return
+	 * @throws Exception
+	 */
+	public abstract String value() throws Exception;
+	
+	
+	/**
+	 * Sets the components value.
+	 * 
+	 * @param value
+	 * @throws Exception
+	 */
+	public abstract  void setValue(String value) throws Exception;
+	
+	
+	/**
+	 * Clears the components value.
+	 * 
+	 * @throws Exception
+	 */
+	public abstract  void clear() throws Exception;
+	
+	
+	/**
+	 * Copies the value from the sourceComponent to this component
+	 * 
+	 * @param sourceComponent
+	 */
+	public void copy(MessageComponent sourceComponent) throws Exception {
+		this.setValue(sourceComponent.value());
+	}
+	
+	
+	/**
+	 * Moves the value from the sourceComponent to this component.  This is a copy followed by a clear.
+	 * 
+	 * @param sourceComponent
+	 */
+	public void move(MessageComponent sourceComponent) throws Exception {
+		copy(sourceComponent);
+		sourceComponent.clear();
+	}
+}

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/PIDSegment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/PIDSegment.java
@@ -1,0 +1,96 @@
+package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transformation.model;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+/**
+ * A PID segment.
+ * 
+ * @author Brendan Douglas
+ *
+ */
+public class PIDSegment extends Segment implements Serializable {
+	private static final long serialVersionUID = -8797054428191615724L;
+	
+	
+	public PIDSegment(String segment, HL7Message message) {
+		super(segment, message);
+	}
+	
+
+	/**
+	 * Removes a patient identifier from the PID segment.
+	 * 
+	 * @param message
+	 * @param identifier
+	 * @throws Exception
+	 */
+	public void removePatientIdentifierField(String identifier) throws Exception  {	
+		Iterator<FieldRepetition>fieldRepetitionIterator = getField(3).getRepetitions().iterator();
+		
+		while (fieldRepetitionIterator.hasNext()) {
+			FieldRepetition fieldRepetition = fieldRepetitionIterator.next();
+			
+			if (fieldRepetition.getSubField(5).value().equals(identifier)) {
+				fieldRepetitionIterator.remove();
+			}
+		}
+	}
+
+	
+	/**
+	 * Gets a patient identifier value from the PID segment
+	 * 
+	 * @param identifier
+	 * @return
+	 * @throws Exception
+	 */
+	public String getPatientIdentifierValue(String identifier) throws Exception  {	
+		
+		for (FieldRepetition fieldRepetition : getField(3).getRepetitions()) {
+			if (fieldRepetition.getSubField(5).value().equals(identifier)) {
+				return fieldRepetition.getSubField(1).value();
+			}
+		}
+		
+		return "";
+	}
+	
+	
+	/**
+	 * Returns a list of patient identifiers in the PID segment.
+	 * 
+	 * @return
+	 * @throws Exception
+	 */
+	public List<String> getPatientIdentifierCodes() throws Exception {	
+		
+		List<String>identifiers = new ArrayList<>();
+		
+		for (FieldRepetition fieldRepetition : getField(3).getRepetitions()) {
+			identifiers.add(fieldRepetition.getSubField(5).value());
+		}
+		
+		
+		return identifiers;
+	}
+	
+	
+	/**
+	 * Removes patient identifiers which do not match the identifier to keep.
+	 * 
+	 * @param identifierToKeep
+	 * @throws Exception
+	 */
+	public void removeOtherPatientIdentifierFields( String identifierToKeep) throws Exception  {		
+		List<String>patientIdentifierCodes = getPatientIdentifierCodes();
+		
+		for (String patientIdentifierCode : patientIdentifierCodes) {
+			if (!patientIdentifierCode.equals(identifierToKeep)) {
+				removePatientIdentifierField( patientIdentifierCode);
+			}
+		}
+	}
+}

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -7,7 +7,6 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 
 import ca.uhn.hl7v2.HL7Exception;
-import ca.uhn.hl7v2.model.Message;
 
 /**
  * A single HL7 message segment.
@@ -15,7 +14,7 @@ import ca.uhn.hl7v2.model.Message;
  * @author Brendan Douglas
  *
  */
-public class Segment implements Serializable {
+public class Segment extends MessageComponent implements Serializable {
 	private static final long serialVersionUID = -8797054428191615724L;
 	
     private List<Field>fields = new ArrayList<Field>();
@@ -516,5 +515,45 @@ public class Segment implements Serializable {
 	public void setSubFieldInAllFieldRepetitions(int fieldIndex, int subFieldIndex, String value) throws Exception {
 		Field field = getField(fieldIndex);
 		field.setSubFieldInAllRepetitions(subFieldIndex, value);
+	}
+
+
+	/**
+	 * Gets a Field repetition which contains the supplied value at the supplied sub field index.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public FieldRepetition getFieldRepetitionContainingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+		Field field = getField(fieldIndex);
+		
+		return field.getRepetitionContainingValue(subFieldIndex, value);
+	}
+
+
+	/**
+	 * Gets a field containing the specified value at the supplied sub field index.  All repetitions are searched.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public Field getFieldContainingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+		Field field = getField(fieldIndex);
+		
+		if (field.doesSubFieldContainValue(subFieldIndex, value)) {
+			return field;
+		}
+		
+		return null;
+	}
+
+
+	@Override
+	public String value() throws Exception {
+		return this.toString();
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -17,8 +17,10 @@ import ca.uhn.hl7v2.HL7Exception;
 public class Segment extends MessageComponent implements Serializable {
 	private static final long serialVersionUID = -8797054428191615724L;
 	
-    private List<Field>fields = new ArrayList<Field>();
-	private HL7Message message = null;
+    protected List<Field>fields = new ArrayList<Field>();
+	protected HL7Message message = null;
+	
+	protected Segment() {};
 	
 	public Segment(String segment, HL7Message message) {
 		this.message = message;
@@ -28,15 +30,7 @@ public class Segment extends MessageComponent implements Serializable {
 		fields.add(new Field(splitSegmentFields[0], true, this));
 		
 		int startIndex = 1;
-			
-		// For the MSH segment the MSH-1 field value is the separator character (|) and we split based on this so create an empty field then add the seperator character to the field.
-		if (segment.startsWith("MSH")) {
-			startIndex = 2;
-			fields.add(new Field("|", false, this));
-			fields.add(new Field(splitSegmentFields[1],false, this));
-        }
-
-		
+					
 		for (int i = startIndex; i < splitSegmentFields.length; i++) {
 			String value = splitSegmentFields[i];
 			Field field = new Field(value, true, this);
@@ -65,15 +59,8 @@ public class Segment extends MessageComponent implements Serializable {
 	}
 
 	
+	@Override
 	public String toString() {	
-	
-		// Hack for MSH segment.
-		if (this.getName().equals("MSH") ) {
-			String segment = fields.stream().skip(3).map(Field::toString).collect(Collectors.joining("|"));
-			
-			return "MSH|^~\\&|"+segment;
-		}
-		
 		return fields.stream().map(Field::toString).collect(Collectors.joining("|"));
 	}
 
@@ -304,6 +291,7 @@ public class Segment extends MessageComponent implements Serializable {
 	/**
 	 * Clears the segment
 	 */
+	@Override
 	public void clear() throws Exception {
 		for (Field field : getFields()) {
 			field.clear();
@@ -461,6 +449,7 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @param clearExistingContent - if true the field value becomes the only value in this field.  All other repetitions are cleared.
 	 * @throws Exception
 	 */
+	@Override
 	public void setValue(String value) throws Exception {
 		fields.clear();
 

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/SubSubfield.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/SubSubfield.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author Bendan_Douglas
  *
  */
-public class SubSubfield implements Serializable {
+public class SubSubfield extends MessageComponent implements Serializable {
 	private static final long serialVersionUID = -8174677055244513493L;
 
 	private String value;

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Subfield.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Subfield.java
@@ -14,7 +14,7 @@ import org.apache.commons.lang3.StringUtils;
  * @author Bendan_Douglas
  *
  */
-public class Subfield implements Serializable {
+public class Subfield extends MessageComponent implements Serializable {
 	private static final long serialVersionUID = -8174677055244513493L;
 
 	private List<SubSubfield> subSubFields = new ArrayList<>();


### PR DESCRIPTION
1) Due to new transformation rules I have needed to add some more reusable methods.

2) Fix an error with the addRepetition method in the Field class.  The code should have been replacing the 1st element, not inserting a new element as the 1st element

3) Create a super class for the hl7 message components.