### PR TITLE
Minor refactor due to some confusion with method names

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -317,7 +317,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param subFieldIndex
 	 * @throws Exception
 	 */
-	public void clearSubFieldFromAllFieldRepetitions(int subFieldIndex) throws Exception {
+	public void clearSubField(int subFieldIndex) throws Exception {
 		for (FieldRepetition repetition : this.getRepetitions()) {
 			repetition.clearSubField(subFieldIndex);
 		}
@@ -352,18 +352,6 @@ public class Field extends MessageComponent implements Serializable {
 		}
 		
 		fieldRepetition.clearSubField(subFieldIndex);
-	}
-
-	
-	/**
-	 * Clears a subfield in the 1st field repetition.
-	 * 
-	 * @param subFieldIndex
-	 * @param repetition
-	 * @throws Exception
-	 */
-	public void clearSubField(int subFieldIndex) throws Exception {
-		clearSubField(subFieldIndex, 0);
 	}
 
 	
@@ -560,19 +548,8 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param startingSubFieldIndex
 	 * @throws Exception
 	 */
-	public void clearSubFieldsFrom(int fieldRepetition, int startingSubFieldIndex) throws Exception {
+	public void clearSubFieldsStartingFrom(int fieldRepetition, int startingSubFieldIndex) throws Exception {
 		clearSubFieldRange(fieldRepetition, startingSubFieldIndex, -1);
-	}
-	
-	
-	/**
-	 * Clears all subFields from the startingSubFieldIndex in the 1st field repetition.
-	 * 
-	 * @param startingSubFieldIndex
-	 * @throws Exception
-	 */
-	public void clearSubFieldsFrom(int startingSubFieldIndex) throws Exception {
-		clearSubFieldRange(0, startingSubFieldIndex, -1);
 	}
 
 	
@@ -582,7 +559,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param startingSubFieldIndex
 	 * @throws Exception
 	 */
-	public void clearSubFieldsFromAllRepetitions(int startingSubFieldIndex) throws Exception {
+	public void clearSubFieldsStartingFrom(int startingSubFieldIndex) throws Exception {
 		for (FieldRepetition repetition : this.repetitions) {
 			repetition.clearSubFieldsFrom(startingSubFieldIndex);
 		}
@@ -608,25 +585,13 @@ public class Field extends MessageComponent implements Serializable {
 
 	
 	/**
-	 * Clears all subFields from the supplied startingFieldIndex to the endingFieldIndex in the 1st field repetition.
-	 * 
-	 * @param startingSubFieldIndex
-	 * @param endingSubFieldIndex
-	 * @throws Exception
-	 */
-	public void clearSubFieldRange(int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
-		clearSubFieldRange(0, startingSubFieldIndex, endingSubFieldIndex);
-	}
-
-	
-	/**
 	 * Clears all subFields from the supplied startingFieldIndex to the endingFieldIndex in all field repetitions.
 	 * 
 	 * @param startingSubFieldIndex
 	 * @param endingSubFieldIndex
 	 * @throws Exception
 	 */
-	public void clearSubFieldRangeAllRepetitions(int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
+	public void clearSubFieldRange(int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
 		for (FieldRepetition fieldRepetition : this.repetitions) {
 			fieldRepetition.clearSubFieldRange(startingSubFieldIndex, endingSubFieldIndex);
 		}
@@ -700,7 +665,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param subFieldIndex
 	 * @param value
 	 */
-	public void setSubFieldInAllRepetitions(int subFieldIndex, String value) throws Exception {
+	public void setSubField(int subFieldIndex, String value) throws Exception {
 
 		for (FieldRepetition repetition : getRepetitions()) {
 			Subfield subField = repetition.getSubField(subFieldIndex);

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -465,8 +465,8 @@ public class HL7Message implements Serializable   {
 	 * @param segment
 	 * @param fieldIndex
 	 */
-	public void clearFieldFromAllSegments(String segmentName, int fieldIndex) throws Exception {
-		setFieldInAllSegments(segmentName, fieldIndex, "");
+	public void clearField(String segmentName, int fieldIndex) throws Exception {
+		setField(segmentName, fieldIndex, "");
 	}
 
 	
@@ -476,7 +476,7 @@ public class HL7Message implements Serializable   {
 	 * @param segment
 	 * @param fieldIndex
 	 */
-	public void setFieldInAllSegments(String segmentName, int fieldIndex, String value) throws Exception {
+	public void setField(String segmentName, int fieldIndex, String value) throws Exception {
 		for (Segment segment : getSegments(segmentName)) {
 			Field field = segment.getField(fieldIndex);
 			
@@ -496,9 +496,9 @@ public class HL7Message implements Serializable   {
 	 * @param fieldIndex
 	 * @param subFieldIndex
 	 */
-	public void setSubFieldInAllFieldRepetitionsAllSegments(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public void setSubField(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
 		for (Segment segment : getSegments(segmentName)) {
-			segment.setSubFieldInAllFieldRepetitions(fieldIndex, subFieldIndex, value);
+			segment.setSubField(fieldIndex, subFieldIndex, value);
 		}
 	}
 
@@ -509,7 +509,7 @@ public class HL7Message implements Serializable   {
 	 * @param segment
 	 * @param startingFieldIndex
 	 */
-	public void clearFieldsFrom(String segmentName, int startingFieldIndex) throws Exception {
+	public void clearFieldsStartingFrom(String segmentName, int startingFieldIndex) throws Exception {
 		clearFieldRange(segmentName, startingFieldIndex, -1);
 	}
 
@@ -525,6 +525,33 @@ public class HL7Message implements Serializable   {
 
 		for (Segment segment : getSegments(segmentName)) {
 			segment.clearFieldRange(startingFieldIndex, endingFieldIndex);
+		}
+	}
+	
+	
+	/**
+	 * Clears all sub fields from a segment starting at the supplied startingSubFieldIndex in all matching segments.
+	 * 
+	 * @param segment
+	 * @param fieldIndex The field to clear the sub fields from
+	 * @param startingSubFieldIndex
+	 */
+	public void clearSubFieldsStartingFrom(String segmentName, int fieldIndex, int startingSubFieldIndex) throws Exception {
+		clearSubFieldRange(segmentName, fieldIndex, startingSubFieldIndex, -1);
+	}
+
+	
+	/**
+	 * Clears all sub fields from the supplied startingSubFieldIndex to the endingSubFieldIndex in all matching segments.
+	 * 
+	 * @param segment
+	 * @param startingFieldIndex
+	 * @param endingFieldIndex
+	 */
+	public void clearSubFieldRange(String segmentName, int fieldIndex, int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
+
+		for (Segment segment : getSegments(segmentName)) {
+			segment.clearSubFieldRange(fieldIndex, startingSubFieldIndex, endingSubFieldIndex);
 		}
 	}
 

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -197,28 +197,16 @@ public class Segment extends MessageComponent implements Serializable {
 
 	
 	/**
-	 * Clears a sub field from the 1st repetition of a field.
-	 * 
-	 * @param fieldIndex
-	 * @param repetition
-	 * @throws Exception
-	 */
-	public void clearSubField(int fieldIndex, int subFieldIndex) throws Exception {
-		clearSubField(fieldIndex, 0, subFieldIndex);
-	}
-	
-	
-	/**
 	 * Clears a subField from all repetitions of a field.
 	 * 
 	 * @param fieldIndex
 	 * @param subFieldIndex
 	 * @throws Exception
 	 */
-	public void clearSubFieldFromAllFieldRepetitions(int fieldIndex, int subFieldIndex) throws Exception {
+	public void clearSubField(int fieldIndex, int subFieldIndex) throws Exception {
 		Field field = this.getField(fieldIndex);
 				
-		field.clearSubFieldFromAllFieldRepetitions(subFieldIndex);		
+		field.clearSubField(subFieldIndex);		
 	}
 
 	
@@ -375,8 +363,18 @@ public class Segment extends MessageComponent implements Serializable {
 	 * 
 	 * @param startingFieldIndex
 	 */
-	public void clearFieldsFrom(int startingFieldIndex) throws Exception {
+	public void clearFieldsStartingFrom(int startingFieldIndex) throws Exception {
 		clearFieldRange(startingFieldIndex, -1);
+	}
+	
+	
+	/**
+	 * Clears all fields from this segment starting at the supplied startingFieldIndex.
+	 * 
+	 * @param startingFieldIndex
+	 */
+	public void clearSubFieldsStartingFrom(int fieldIndex, int startingSubFieldIndex) throws Exception {
+		clearSubFieldRange(fieldIndex, startingSubFieldIndex, -1);
 	}
 	
 	
@@ -415,6 +413,20 @@ public class Segment extends MessageComponent implements Serializable {
 				field.clear();
 			}
 		}
+	}
+	
+	
+	/**
+	 * Clears all fields from the supplied startingFieldIndex to the endingFieldIndex in this segment.
+	 * 
+	 * @param startingFieldIndex
+	 * @param endingFieldIndex
+	 * @throws Exception
+	 */
+	public void clearSubFieldRange(int fieldIndex, int startingSubFieldIndex, int endingSubFieldIndex) throws Exception {
+		Field field = getField(fieldIndex);
+		
+		field.clearSubFieldRange(startingSubFieldIndex, endingSubFieldIndex);
 	}
 
 	
@@ -499,9 +511,9 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @param value
 	 * @throws Exception
 	 */
-	public void setSubFieldInAllFieldRepetitions(int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public void setSubField(int fieldIndex, int subFieldIndex, String value) throws Exception {
 		Field field = getField(fieldIndex);
-		field.setSubFieldInAllRepetitions(subFieldIndex, value);
+		field.setSubField(subFieldIndex, value);
 	}
 
 


### PR DESCRIPTION
There was some confusion with method names in the transformation templates.  Simplify.  One example was the clearSubField method which only cleared the 1st repetition.  

There was other clearSubField methods which cleared all repetitions or a repetition could be provided.  The clearSubField method without a repetition will now clear the sub field from all repetitions.