### PR TITLE
Feature/264139 rename methods for consistency

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -604,9 +604,9 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesFieldContainValue(String value) {
+	public boolean doesFieldMatchValue(String value) {
 		for (FieldRepetition fieldRepetition : this.repetitions) {
-			if (fieldRepetition.value().contains(value)) {
+			if (fieldRepetition.value().equals(value)) {
 				return true;
 			}
 		}
@@ -623,9 +623,9 @@ public class Field extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesSubFieldContainValue(int subFieldIndex, String value) throws Exception {
+	public boolean doesSubFieldMatchValue(int subFieldIndex, String value) throws Exception {
 		for (FieldRepetition fieldRepetition : this.repetitions) {
-			if (fieldRepetition.getSubField(subFieldIndex).value().contains(value)) {
+			if (fieldRepetition.getSubField(subFieldIndex).value().equals(value)) {
 				return true;
 			}
 		}
@@ -641,7 +641,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param matchValue
 	 */
 	public void removeMatchingFieldRepetitions(int subFieldIndex, String matchValue) throws Exception {
-		List<FieldRepetition> fieldRepetitions = this.getRepetitionsContainingValue(subFieldIndex, matchValue);
+		List<FieldRepetition> fieldRepetitions = this.getRepetitionsMatchingValue(subFieldIndex, matchValue);
 		this.repetitions.removeAll(fieldRepetitions);
 	}
 
@@ -654,7 +654,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @throws Exception
 	 */
 	public void removeNotMatchingFieldRepetitions(int subFieldIndex, String ... matchValue) throws Exception {	
-		List<FieldRepetition>fieldRepetitions = this.getRepetitionsNotContainingValue(subFieldIndex, matchValue);
+		List<FieldRepetition>fieldRepetitions = this.getRepetitionsNotMatchingValue(subFieldIndex, matchValue);
 		this.repetitions.removeAll(fieldRepetitions);
 	}
 
@@ -678,14 +678,14 @@ public class Field extends MessageComponent implements Serializable {
 
 
 	/**
-	 * Returns a repetition of this field containing the supplied value at the supplied sub field index.  The first match is returned.
+	 * Returns a repetition of this field Matching the supplied value at the supplied sub field index.  The first match is returned.
 	 * 
 	 * @param subFieldIndex
 	 * @param value
 	 * @return
 	 * @throws Exception
 	 */
-	public FieldRepetition getRepetitionContainingValue(int subFieldIndex, String value) throws Exception {
+	public FieldRepetition getRepetitionMatchingValue(int subFieldIndex, String value) throws Exception {
 		for (FieldRepetition repetition : getRepetitions()) {
 			Subfield subField = repetition.getSubField(subFieldIndex);
 			
@@ -699,14 +699,14 @@ public class Field extends MessageComponent implements Serializable {
 	
 	
 	/**
-	 * Returns a list of repetitions of this field containing the supplied value at the supplied sub field index.
+	 * Returns a list of repetitions of this field Matching the supplied value at the supplied sub field index.
 	 * 
 	 * @param subFieldIndex
 	 * @param value
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FieldRepetition> getRepetitionsContainingValue(int subFieldIndex, String value) throws Exception {
+	public List<FieldRepetition> getRepetitionsMatchingValue(int subFieldIndex, String value) throws Exception {
 		List<FieldRepetition>fieldRepetitions = new ArrayList<>();
 		
 		for (FieldRepetition repetition : getRepetitions()) {
@@ -722,14 +722,14 @@ public class Field extends MessageComponent implements Serializable {
 	
 	
 	/**
-	 * Returns a list of Field repetitions of this field not containing the supplied value at the supplied sub field index.
+	 * Returns a list of Field repetitions of this field not Matching the supplied value at the supplied sub field index.
 	 * 
 	 * @param subFieldIndex
 	 * @param value
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FieldRepetition> getRepetitionsNotContainingValue(int subFieldIndex, String ... values) throws Exception {
+	public List<FieldRepetition> getRepetitionsNotMatchingValue(int subFieldIndex, String ... values) throws Exception {
 		List<FieldRepetition>fieldRepetitions = new ArrayList<>();
 		
 		List<String>valuesToCompare = new ArrayList<>();

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -605,8 +605,19 @@ public class Field extends MessageComponent implements Serializable {
 	 * @return
 	 */
 	public boolean doesFieldMatchValue(String value) {
+		return doesFieldMatchValue("equals", value);
+	}
+	
+	
+	/**
+	 * 
+	 * 
+	 * @param value
+	 * @return
+	 */
+	public boolean doesFieldMatchValue(String matchType, String ... matchValues) {
 		for (FieldRepetition fieldRepetition : this.repetitions) {
-			if (fieldRepetition.value().equals(value)) {
+			if (compare(matchType, fieldRepetition.value(), matchValues)) {
 				return true;
 			}
 		}
@@ -623,9 +634,9 @@ public class Field extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesSubFieldMatchValue(int subFieldIndex, String value) throws Exception {
+	public boolean doesSubFieldMatchValue(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
 		for (FieldRepetition fieldRepetition : this.repetitions) {
-			if (fieldRepetition.getSubField(subFieldIndex).value().equals(value)) {
+			if (compare(matchType, fieldRepetition.getSubField(subFieldIndex).value(), matchValues)) {
 				return true;
 			}
 		}
@@ -635,13 +646,37 @@ public class Field extends MessageComponent implements Serializable {
 	
 	
 	/**
+	 * 
+	 * 
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public boolean doesSubFieldMatchValue(int subFieldIndex, String value) throws Exception {
+		return doesSubFieldMatchValue("equals", subFieldIndex, value);
+	}
+	
+	
+	/**
 	 * Removes field repetitions where the matchValue matches the subField value. 
 	 * 
 	 * @param subFieldIndex
 	 * @param matchValue
 	 */
-	public void removeMatchingFieldRepetitions(int subFieldIndex, String matchValue) throws Exception {
-		List<FieldRepetition> fieldRepetitions = this.getRepetitionsMatchingValue(subFieldIndex, matchValue);
+	public void removeMatchingFieldRepetitions(int subFieldIndex, String ... matchValues) throws Exception {
+		removeMatchingFieldRepetitions("equals", subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Removes field repetitions where the matchValue matches the subField value. 
+	 * 
+	 * @param subFieldIndex
+	 * @param matchValue
+	 */
+	public void removeMatchingFieldRepetitions(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
+		List<FieldRepetition> fieldRepetitions = this.getRepetitionsMatchingValue(matchType, subFieldIndex, matchValues);
 		this.repetitions.removeAll(fieldRepetitions);
 	}
 
@@ -653,8 +688,20 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param matchValue
 	 * @throws Exception
 	 */
-	public void removeNotMatchingFieldRepetitions(int subFieldIndex, String ... matchValue) throws Exception {	
-		List<FieldRepetition>fieldRepetitions = this.getRepetitionsNotMatchingValue(subFieldIndex, matchValue);
+	public void removeNotMatchingFieldRepetitions(int subFieldIndex, String ... matchValues) throws Exception {	
+		removeNotMatchingFieldRepetitions("equals", subFieldIndex, matchValues);
+	}
+	
+
+	/**
+	 * Removes field repetitions where the matchValue does not match the subField value.
+	 * 
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeNotMatchingFieldRepetitions(String matchType, int subFieldIndex, String ... matchValues) throws Exception {	
+		List<FieldRepetition>fieldRepetitions = this.getRepetitionsNotMatchingValue(matchType, subFieldIndex, matchValues);
 		this.repetitions.removeAll(fieldRepetitions);
 	}
 
@@ -685,16 +732,29 @@ public class Field extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public FieldRepetition getRepetitionMatchingValue(int subFieldIndex, String value) throws Exception {
+	public FieldRepetition getRepetitionMatchingValue(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
 		for (FieldRepetition repetition : getRepetitions()) {
 			Subfield subField = repetition.getSubField(subFieldIndex);
 			
-			if (subField.value().equals(value)) {
+			if (compare(matchType, subField.value(), matchValues)) {
 				return repetition;
 			}
 		}
 		
 		return null;
+	}
+	
+	
+	/**
+	 * Returns a repetition of this field Matching the supplied value at the supplied sub field index.  The first match is returned.
+	 * 
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public FieldRepetition getRepetitionMatchingValue(int subFieldIndex, String ...matchValues) throws Exception {
+		return getRepetitionMatchingValue("equals", subFieldIndex, matchValues);
 	}
 	
 	
@@ -706,13 +766,13 @@ public class Field extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FieldRepetition> getRepetitionsMatchingValue(int subFieldIndex, String value) throws Exception {
+	public List<FieldRepetition> getRepetitionsMatchingValue(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
 		List<FieldRepetition>fieldRepetitions = new ArrayList<>();
 		
 		for (FieldRepetition repetition : getRepetitions()) {
 			Subfield subField = repetition.getSubField(subFieldIndex);
 			
-			if (subField.value().equals(value)) {
+			if (compare(matchType, subField.value(), matchValues)) {
 				fieldRepetitions.add(repetition);
 			}
 		}
@@ -722,30 +782,96 @@ public class Field extends MessageComponent implements Serializable {
 	
 	
 	/**
-	 * Returns a list of Field repetitions of this field not Matching the supplied value at the supplied sub field index.
+	 * Returns a list of repetitions of this field Matching the supplied value at the supplied sub field index.
 	 * 
 	 * @param subFieldIndex
 	 * @param value
 	 * @return
 	 * @throws Exception
 	 */
-	public List<FieldRepetition> getRepetitionsNotMatchingValue(int subFieldIndex, String ... values) throws Exception {
+	public List<FieldRepetition> getRepetitionsMatchingValue(int subFieldIndex, String ... matchValues) throws Exception {
+		return getRepetitionsMatchingValue("equals", subFieldIndex, matchValues);
+	}
+
+	
+	/**
+	 * Returns a list of Field repetitions of this field not Matching one of the supplied value at the supplied sub field index.
+	 * 
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public List<FieldRepetition> getRepetitionsNotMatchingValue(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
 		List<FieldRepetition>fieldRepetitions = new ArrayList<>();
 		
-		List<String>valuesToCompare = new ArrayList<>();
-		for (String value : values) {
-			valuesToCompare.add(value);
-		}
-		
-		
+	
 		for (FieldRepetition repetition : getRepetitions()) {
 			Subfield subField = repetition.getSubField(subFieldIndex);
-			
-			if (!valuesToCompare.contains(subField.value())) {
+
+			if (!compare(matchType, subField.value(), matchValues)) {
 				fieldRepetitions.add(repetition);
 			}
 		}
 		
 		return fieldRepetitions;
+	}
+	
+	
+	/**
+	 * Returns a list of Field repetitions of this field not Matching one of the supplied value at the supplied sub field index.
+	 * 
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public List<FieldRepetition> getRepetitionsNotMatchingValue(int subFieldIndex, String ... matchValues) throws Exception {
+		return getRepetitionsNotMatchingValue("equals", subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Does one of the supplied match values match the text using the supplied match type.
+	 * 
+	 * @param matchType
+	 * @param text
+	 * @param compareValue
+	 * @return
+	 */
+	private boolean compare(String matchType, String text, String ... matchValues) {
+		MatchTypeEnum type = MatchTypeEnum.get(matchType);
+		
+		
+		for (String matchValue : matchValues) {
+		
+			switch (type) {
+				case EQUALS:
+					if  (text.equals(matchValue)) {
+						return true;
+					}
+					break;
+				case CONTAINS:
+					if (text.contains(matchValue)) {
+						return true;
+					}
+				case ENDS_WITH:
+					if (text.endsWith(matchValue)) {
+						return true;
+					}
+					break;
+				case STARTS_WITH:
+					if (text.startsWith(matchValue)) {
+						return true;
+					}
+					break;
+				default:
+					if (text.equals(matchValue)) {
+						return true;
+					}
+			}
+		}
+		
+		return false;
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -604,8 +604,8 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesFieldMatchValue(String value) {
-		return doesFieldMatchValue("equals", value);
+	public boolean hasFieldMatchingValue(String value) {
+		return hasFieldMatchingValue("equals", value);
 	}
 	
 	
@@ -615,7 +615,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesFieldMatchValue(String matchType, String ... matchValues) {
+	public boolean hasFieldMatchingValue(String matchType, String ... matchValues) {
 		for (FieldRepetition fieldRepetition : this.repetitions) {
 			if (compare(matchType, fieldRepetition.value(), matchValues)) {
 				return true;
@@ -634,7 +634,7 @@ public class Field extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesSubFieldMatchValue(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
+	public boolean hasSubFieldMatchingValue(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
 		for (FieldRepetition fieldRepetition : this.repetitions) {
 			if (compare(matchType, fieldRepetition.getSubField(subFieldIndex).value(), matchValues)) {
 				return true;
@@ -653,8 +653,8 @@ public class Field extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesSubFieldMatchValue(int subFieldIndex, String value) throws Exception {
-		return doesSubFieldMatchValue("equals", subFieldIndex, value);
+	public boolean hasSubFieldMatchingValue(int subFieldIndex, String value) throws Exception {
+		return hasSubFieldMatchingValue("equals", subFieldIndex, value);
 	}
 	
 	

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -701,9 +701,9 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesFieldContainValue(String segmentName, int fieldIndex, String value) throws Exception {
+	public boolean doesFieldMatchValue(String segmentName, int fieldIndex, String value) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			if (segment.doesFieldContainValue(fieldIndex, value)) {
+			if (segment.doesFieldMatchValue(fieldIndex, value)) {
 				return true;
 			}
 		}
@@ -721,9 +721,9 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesSubFieldContainValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public boolean doesSubFieldMatchValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			if (segment.doesSubFieldContainValue(fieldIndex, subFieldIndex, value)) {
+			if (segment.doesSubFieldMatchValue(fieldIndex, subFieldIndex, value)) {
 				return true;
 			}
 		}
@@ -733,7 +733,7 @@ public class HL7Message implements Serializable   {
 	
 	
 	/**
-	 * Gets a Segment containing the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
+	 * Gets a Segment Matching the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
 	 * 
 	 * @param segmentName
 	 * @param fieldIndex
@@ -741,9 +741,9 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public Segment getSegmentContainingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public Segment getSegmentMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesSubFieldContainValue(fieldIndex, subFieldIndex, value)) {
+			if (segment.doesSubFieldMatchValue(fieldIndex, subFieldIndex, value)) {
 				return segment;
 			}
 		}
@@ -753,7 +753,7 @@ public class HL7Message implements Serializable   {
 
 	
 	/**
-	 * Gets a list of  segments containing the specified value.  All matching segments are searched.  All field repetitions are searched
+	 * Gets a list of  segments Matching the specified value.  All matching segments are searched.  All field repetitions are searched
 	 * 
 	 * @param segmentName
 	 * @param fieldIndex
@@ -761,11 +761,11 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public List<Segment> getSegmentsContainingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public List<Segment> getSegmentsMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
 		List<Segment>segments = new ArrayList<>();
 		
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesSubFieldContainValue(fieldIndex, subFieldIndex, value)) {
+			if (segment.doesSubFieldMatchValue(fieldIndex, subFieldIndex, value)) {
 				segments.add(segment);
 			}
 		}
@@ -775,7 +775,7 @@ public class HL7Message implements Serializable   {
 
 	
 	/**
-	 * Gets a Segment containing the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
+	 * Gets a Segment Matching the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
 	 * 
 	 * @param segmentName
 	 * @param fieldIndex
@@ -783,9 +783,9 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public Segment getSegmentContainingValue(String segmentName, int fieldIndex, String value) throws Exception {
+	public Segment getSegmentMatchingValue(String segmentName, int fieldIndex, String value) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesFieldContainValue(fieldIndex, value)) {
+			if (segment.doesFieldMatchValue(fieldIndex, value)) {
 				return segment;
 			}
 		}
@@ -795,7 +795,7 @@ public class HL7Message implements Serializable   {
 	
 	
 	/**
-	 * Gets a list of segments containing the specified value.  All matching segments are searched.  All field repetitions are searched.
+	 * Gets a list of segments Matching the specified value.  All matching segments are searched.  All field repetitions are searched.
 	 * 
 	 * @param segmentName
 	 * @param fieldIndex
@@ -803,11 +803,11 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public List<Segment> getSegmentsContainingValue(String segmentName, int fieldIndex, String value) throws Exception {
+	public List<Segment> getSegmentsMatchingValue(String segmentName, int fieldIndex, String value) throws Exception {
 		List<Segment>segments = new ArrayList<>();
 		
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesFieldContainValue(fieldIndex, value)) {
+			if (segment.doesFieldMatchValue(fieldIndex, value)) {
 				segments.add(segment);
 			}
 		}
@@ -823,8 +823,8 @@ public class HL7Message implements Serializable   {
 	 * @param fieldIndex
 	 * @param value
 	 */
-	public void removeSegmentsContainingValue(String segmentName, int fieldIndex, String value) throws Exception {
-		List<Segment>segments = this.getSegmentsContainingValue(segmentName, fieldIndex, value);
+	public void removeSegmentsMatchingValue(String segmentName, int fieldIndex, String value) throws Exception {
+		List<Segment>segments = this.getSegmentsMatchingValue(segmentName, fieldIndex, value);
 		removeSegments(segments);
 	}
 
@@ -837,8 +837,8 @@ public class HL7Message implements Serializable   {
 	 * @param subFieldIndex
 	 * @param value
 	 */
-	public void removeSegmentsContainingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
-		List<Segment>segments = this.getSegmentsContainingValue(segmentName, fieldIndex, subFieldIndex, value);
+	public void removeSegmentsMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+		List<Segment>segments = this.getSegmentsMatchingValue(segmentName, fieldIndex, subFieldIndex, value);
 		removeSegments(segments);		
 	}
 
@@ -871,6 +871,16 @@ public class HL7Message implements Serializable   {
 			segment.removeNotMatchingFieldRepetitions(fieldIndex, subFieldIndex, matchValue);
 		}
 	}
+	
+	
+	
+	public void removeNotMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String matchValue, String matchType) throws Exception {
+		for (Segment segment : this.getSegments(segmentName)) {
+			segment.removeNotMatchingFieldRepetitions(fieldIndex, subFieldIndex, matchType, matchValue);
+		}
+	}
+		
+	
 	
 	/**
 	 * Returns a segment.

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -701,9 +701,24 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesFieldMatchValue(String segmentName, int fieldIndex, String value) throws Exception {
+	public boolean doesFieldMatchValue(String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+		return doesFieldMatchValue("equals", segmentName, fieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 *  * Does the supplied value appear in the specified field of any matching segment.  All field repetitions are checked.
+	 * 
+	 * @param matchType The type of match to perform.
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public boolean doesFieldMatchValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			if (segment.doesFieldMatchValue(fieldIndex, value)) {
+			if (segment.doesFieldMatchValue(matchType, fieldIndex, matchValues)) {
 				return true;
 			}
 		}
@@ -721,9 +736,23 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesSubFieldMatchValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public boolean doesSubFieldMatchValue(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return doesSubFieldMatchValue("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Does the supplied value appear in the specified subField of any matching segment.  All field repetitions are checked.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public boolean doesSubFieldMatchValue(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			if (segment.doesSubFieldMatchValue(fieldIndex, subFieldIndex, value)) {
+			if (segment.doesSubFieldMatchValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
 				return true;
 			}
 		}
@@ -741,9 +770,23 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public Segment getSegmentMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public Segment getSegmentMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return getSegmentMatchingValue("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Gets a Segment Matching the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public Segment getSegmentMatchingValue(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesSubFieldMatchValue(fieldIndex, subFieldIndex, value)) {
+			if (segment.doesSubFieldMatchValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
 				return segment;
 			}
 		}
@@ -761,11 +804,25 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public List<Segment> getSegmentsMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public List<Segment> getSegmentsMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return getSegmentsMatchingValue("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Gets a list of  segments Matching the specified value.  All matching segments are searched.  All field repetitions are searched
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public List<Segment> getSegmentsMatchingValue(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		List<Segment>segments = new ArrayList<>();
 		
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesSubFieldMatchValue(fieldIndex, subFieldIndex, value)) {
+			if (segment.doesSubFieldMatchValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
 				segments.add(segment);
 			}
 		}
@@ -783,16 +840,29 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public Segment getSegmentMatchingValue(String segmentName, int fieldIndex, String value) throws Exception {
+	public Segment getSegmentMatchingValue(String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+		return getSegmentMatchingValue("equals", segmentName, fieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Gets a Segment Matching the specified value.  All matching segments are searched.  All field repetitions are searched.  The first match is returned.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public Segment getSegmentMatchingValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesFieldMatchValue(fieldIndex, value)) {
+			if (segment.doesFieldMatchValue(matchType, fieldIndex, matchValues)) {
 				return segment;
 			}
 		}
 		
 		return null;
 	}
-	
 	
 	/**
 	 * Gets a list of segments Matching the specified value.  All matching segments are searched.  All field repetitions are searched.
@@ -803,11 +873,24 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public List<Segment> getSegmentsMatchingValue(String segmentName, int fieldIndex, String value) throws Exception {
+	public List<Segment> getSegmentsMatchingValue(String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+		return getSegmentsMatchingValue("equals", segmentName, fieldIndex, matchValues);
+	}
+	
+	/**
+	 * Gets a list of segments Matching the specified value.  All matching segments are searched.  All field repetitions are searched.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public List<Segment> getSegmentsMatchingValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
 		List<Segment>segments = new ArrayList<>();
 		
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesFieldMatchValue(fieldIndex, value)) {
+			if (segment.doesFieldMatchValue(matchType, fieldIndex, matchValues)) {
 				segments.add(segment);
 			}
 		}
@@ -823,8 +906,20 @@ public class HL7Message implements Serializable   {
 	 * @param fieldIndex
 	 * @param value
 	 */
-	public void removeSegmentsMatchingValue(String segmentName, int fieldIndex, String value) throws Exception {
-		List<Segment>segments = this.getSegmentsMatchingValue(segmentName, fieldIndex, value);
+	public void removeSegmentsMatchingValue(String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+		removeSegmentsMatchingValue("equals", segmentName, fieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Removes all matching segments.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param value
+	 */
+	public void removeSegmentsMatchingValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+		List<Segment>segments = this.getSegmentsMatchingValue(matchType, segmentName, fieldIndex, matchValues);
 		removeSegments(segments);
 	}
 
@@ -837,8 +932,21 @@ public class HL7Message implements Serializable   {
 	 * @param subFieldIndex
 	 * @param value
 	 */
-	public void removeSegmentsMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String value) throws Exception {
-		List<Segment>segments = this.getSegmentsMatchingValue(segmentName, fieldIndex, subFieldIndex, value);
+	public void removeSegmentsMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		removeSegmentsMatchingValue("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Removes all matching segments.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 */
+	public void removeSegmentsMatchingValue(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		List<Segment>segments = this.getSegmentsMatchingValue(matchType, segmentName, fieldIndex, subFieldIndex, matchValues);
 		removeSegments(segments);		
 	}
 
@@ -851,32 +959,53 @@ public class HL7Message implements Serializable   {
 	 * @param matchValue
 	 * @return
 	 */
-	public void removeMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
-		for (Segment segment : this.getSegments(segmentName)) {
-			segment.removeMatchingFieldRepetitions(fieldIndex, subFieldIndex, matchValue);
-		}
+	public void removeMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		removeMatchingFieldRepetitions("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
 	}
-
+	
 	
 	/**
-	 * Removes a field repetition where the matchValue does not match the subField value.
+	 * Removes a field repetitions.
 	 * 
 	 * @param fieldIndex
 	 * @param subFieldIndex
 	 * @param matchValue
 	 * @return
 	 */
-	public void removeNotMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+	public void removeMatchingFieldRepetitions(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			segment.removeNotMatchingFieldRepetitions(fieldIndex, subFieldIndex, matchValue);
+			segment.removeMatchingFieldRepetitions(matchType, fieldIndex, subFieldIndex, matchValues);
 		}
 	}
 	
 	
+	/**
+	 * Removes a field repetitions.
+	 * 
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeNotMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		removeNotMatchingFieldRepetitions("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
+	}
 	
-	public void removeNotMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String matchValue, String matchType) throws Exception {
+	
+	/**
+	 * Removes field repetitions.
+	 * 
+	 * @param matchType
+	 * @param segmentName
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeNotMatchingFieldRepetitions(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			segment.removeNotMatchingFieldRepetitions(fieldIndex, subFieldIndex, matchType, matchValue);
+			segment.removeNotMatchingFieldRepetitions(matchType, fieldIndex, subFieldIndex, matchValues);
 		}
 	}
 		
@@ -1038,6 +1167,7 @@ public class HL7Message implements Serializable   {
 	
 	
 	/**
+	 * 
 	 * @param segmentName
 	 * @param requiredSegments
 	 * @return

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -702,7 +702,7 @@ public class HL7Message implements Serializable   {
 	 * @return
 	 */
 	public boolean hasFieldMatchingValue(String segmentName, int fieldIndex, String ... matchValues) throws Exception {
-		return haaFieldMatchingValue("equals", segmentName, fieldIndex, matchValues);
+		return hasFieldMatchingValue("equals", segmentName, fieldIndex, matchValues);
 	}
 	
 	
@@ -716,7 +716,7 @@ public class HL7Message implements Serializable   {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean haaFieldMatchingValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+	public boolean hasFieldMatchingValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
 			if (segment.hasFieldMatchingValue(matchType, fieldIndex, matchValues)) {
 				return true;

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -701,8 +701,8 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesFieldMatchValue(String segmentName, int fieldIndex, String ... matchValues) throws Exception {
-		return doesFieldMatchValue("equals", segmentName, fieldIndex, matchValues);
+	public boolean hasFieldMatchingValue(String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+		return haaFieldMatchingValue("equals", segmentName, fieldIndex, matchValues);
 	}
 	
 	
@@ -716,9 +716,9 @@ public class HL7Message implements Serializable   {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesFieldMatchValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
+	public boolean haaFieldMatchingValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			if (segment.doesFieldMatchValue(matchType, fieldIndex, matchValues)) {
+			if (segment.hasFieldMatchingValue(matchType, fieldIndex, matchValues)) {
 				return true;
 			}
 		}
@@ -736,8 +736,8 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesSubFieldMatchValue(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		return doesSubFieldMatchValue("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
+	public boolean hasSubFieldMatchingValue(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return hasSubFieldMatchingValue("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
 	}
 	
 	
@@ -750,9 +750,9 @@ public class HL7Message implements Serializable   {
 	 * @param value
 	 * @return
 	 */
-	public boolean doesSubFieldMatchValue(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+	public boolean hasSubFieldMatchingValue(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {
-			if (segment.doesSubFieldMatchValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
+			if (segment.hasSubFieldMatchingValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
 				return true;
 			}
 		}
@@ -786,7 +786,7 @@ public class HL7Message implements Serializable   {
 	 */
 	public Segment getSegmentMatchingValue(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesSubFieldMatchValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
+			if (segment.hasSubFieldMatchingValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
 				return segment;
 			}
 		}
@@ -822,7 +822,7 @@ public class HL7Message implements Serializable   {
 		List<Segment>segments = new ArrayList<>();
 		
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesSubFieldMatchValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
+			if (segment.hasSubFieldMatchingValue(matchType, fieldIndex, subFieldIndex, matchValues)) {
 				segments.add(segment);
 			}
 		}
@@ -856,7 +856,7 @@ public class HL7Message implements Serializable   {
 	 */
 	public Segment getSegmentMatchingValue(String matchType, String segmentName, int fieldIndex, String ... matchValues) throws Exception {
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesFieldMatchValue(matchType, fieldIndex, matchValues)) {
+			if (segment.hasFieldMatchingValue(matchType, fieldIndex, matchValues)) {
 				return segment;
 			}
 		}
@@ -890,7 +890,7 @@ public class HL7Message implements Serializable   {
 		List<Segment>segments = new ArrayList<>();
 		
 		for (Segment segment : this.getSegments(segmentName)) {			
-			if (segment.doesFieldMatchValue(matchType, fieldIndex, matchValues)) {
+			if (segment.hasFieldMatchingValue(matchType, fieldIndex, matchValues)) {
 				segments.add(segment);
 			}
 		}

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MatchTypeEnum.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MatchTypeEnum.java
@@ -1,0 +1,36 @@
+package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transformation.model;
+
+/**
+ * The type of match to perform.
+ * 
+ * @author Brendan Douglas
+ *
+ */
+public enum MatchTypeEnum {
+	EQUALS("equals"),
+	CONTAINS("contains"),
+	STARTS_WITH("starts"),
+	ENDS_WITH("end");
+	
+	private String type;
+	
+	MatchTypeEnum(String type) {
+		this.type = type;
+	}
+	
+	
+	public String getType() {
+		return type;
+	}
+	
+	
+	public static MatchTypeEnum get(String type) {
+		for (MatchTypeEnum matchType : values()) {
+			if (matchType.type.equalsIgnoreCase(type)) {
+				return matchType;
+			}
+		}
+		
+		return EQUALS; // The default is equals.
+	}
+}

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MatchTypeEnum.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MatchTypeEnum.java
@@ -9,8 +9,8 @@ package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.transfo
 public enum MatchTypeEnum {
 	EQUALS("equals"),
 	CONTAINS("contains"),
-	STARTS_WITH("starts"),
-	ENDS_WITH("end");
+	STARTS_WITH("starts-with"),
+	ENDS_WITH("ends-with");
 	
 	private String type;
 	

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/PIDSegment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/PIDSegment.java
@@ -39,7 +39,7 @@ public class PIDSegment extends Segment implements Serializable {
 	 * @throws Exception
 	 */
 	public String getPatientIdentifierValue(String identifier) throws Exception  {	
-		FieldRepetition fieldRepetition = this.getFieldRepetitionContainingValue(3, 5, identifier);
+		FieldRepetition fieldRepetition = this.getFieldRepetitionMatchingValue(3, 5, identifier);
 		
 		if (fieldRepetition != null) {
 			return fieldRepetition.getSubField(1).value();

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -439,16 +439,35 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @throws Exception
 	 */
 	public boolean doesFieldMatchValue(int fieldIndex, String value) throws Exception {
+		return doesFieldMatchValue("equals", fieldIndex, value);
+	}
+	
+	
+	/**
+	 * Does any repetition of the field in this segment match the supplied value.
+	 * 
+	 * @param matchType
+	 * @param fieldIndex
+	 * @param value
+	 * @return
+	 * @throws Exception
+	 */
+	public boolean doesFieldMatchValue(String matchType, int fieldIndex, String ... matchValues) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.doesFieldMatchValue(value);
+		return field.doesFieldMatchValue(matchType, matchValues);
 	}
 
 	
-	public boolean doesSubFieldMatchValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public boolean doesSubFieldMatchValue(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return doesSubFieldMatchValue("equals", fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	public boolean doesSubFieldMatchValue(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.doesSubFieldMatchValue(subFieldIndex, value);
+		return field.doesSubFieldMatchValue(matchType, subFieldIndex, matchValues);
 	}
 	
 	
@@ -482,10 +501,23 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @param matchValue
 	 * @throws Exception
 	 */
-	public void removeMatchingFieldRepetitions(int fieldIndex, int subFieldIndex, String matchValue) throws Exception {
+	public void removeMatchingFieldRepetitions(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		removeMatchingFieldRepetitions("equals", fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Removes a field repetition where the matchValue matches the subField value.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeMatchingFieldRepetitions(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		Field field = this.getField(fieldIndex);
 		
-		field.removeMatchingFieldRepetitions(subFieldIndex, matchValue);	
+		field.removeMatchingFieldRepetitions(matchType, subFieldIndex, matchValues);	
 	}
 
 
@@ -497,9 +529,22 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @param matchValue
 	 * @throws Exception
 	 */
-	public void removeNotMatchingFieldRepetitions(int fieldIndex, int subFieldIndex, String ... matchValue) throws Exception {
+	public void removeNotMatchingFieldRepetitions(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		removeNotMatchingFieldRepetitions("equals", fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Removes field repetitions which do not match one of the supplied values.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param matchValue
+	 * @throws Exception
+	 */
+	public void removeNotMatchingFieldRepetitions(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		Field field = this.getField(fieldIndex);
-		field.removeNotMatchingFieldRepetitions(subFieldIndex, matchValue);
+		field.removeNotMatchingFieldRepetitions(matchType, subFieldIndex, matchValues);
 	}
 
 
@@ -525,10 +570,8 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @param value
 	 * @return
 	 */
-	public FieldRepetition getFieldRepetitionMatchingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
-		Field field = getField(fieldIndex);
-		
-		return field.getRepetitionMatchingValue(subFieldIndex, value);
+	public FieldRepetition getFieldRepetitionMatchingValue(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return getFieldRepetitionMatchingValue("equals", fieldIndex, subFieldIndex, matchValues);
 	}
 	
 	
@@ -540,10 +583,38 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @param value
 	 * @return
 	 */
-	public List<FieldRepetition> getFieldRepetitionsMatchingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public FieldRepetition getFieldRepetitionMatchingValue(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.getRepetitionsMatchingValue(subFieldIndex, value);
+		return field.getRepetitionMatchingValue(matchType, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Gets a Field repetition which matches the supplied value at the supplied sub field index.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public List<FieldRepetition> getFieldRepetitionsMatchingValue(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return getFieldRepetitionsMatchingValue("equals", fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Gets a Field repetition which matches the supplied value at the supplied sub field index.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public List<FieldRepetition> getFieldRepetitionsMatchingValue(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		Field field = getField(fieldIndex);
+		
+		return field.getRepetitionsMatchingValue(matchType, subFieldIndex, matchValues);
 	}
 
 	
@@ -555,10 +626,23 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @param value
 	 * @return
 	 */
-	public List<FieldRepetition> getFieldRepetitionsNotMatchingValue(int fieldIndex, int subFieldIndex, String ... values) throws Exception {
+	public List<FieldRepetition> getFieldRepetitionsNotMatchingValue(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return getFieldRepetitionsNotMatchingValue("equals", fieldIndex, subFieldIndex, matchValues);
+	}
+	
+	
+	/**
+	 * Gets a list of Field repetitions which do not match the supplied value at the supplied sub field index.
+	 * 
+	 * @param fieldIndex
+	 * @param subFieldIndex
+	 * @param value
+	 * @return
+	 */
+	public List<FieldRepetition> getFieldRepetitionsNotMatchingValue(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.getRepetitionsNotMatchingValue(subFieldIndex, values);
+		return field.getRepetitionsNotMatchingValue(matchType, subFieldIndex, matchValues);
 	}
 	
 	

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -438,8 +438,8 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesFieldMatchValue(int fieldIndex, String value) throws Exception {
-		return doesFieldMatchValue("equals", fieldIndex, value);
+	public boolean hasFieldMatchingValue(int fieldIndex, String ... matchValues) throws Exception {
+		return hasFieldMatchingValue("equals", fieldIndex, matchValues);
 	}
 	
 	
@@ -452,22 +452,22 @@ public class Segment extends MessageComponent implements Serializable {
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesFieldMatchValue(String matchType, int fieldIndex, String ... matchValues) throws Exception {
+	public boolean hasFieldMatchingValue(String matchType, int fieldIndex, String ... matchValues) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.doesFieldMatchValue(matchType, matchValues);
+		return field.hasFieldMatchingValue(matchType, matchValues);
 	}
 
 	
-	public boolean doesSubFieldMatchValue(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		return doesSubFieldMatchValue("equals", fieldIndex, subFieldIndex, matchValues);
+	public boolean hasSubFieldMatchingValue(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+		return hasSubFieldMatchingValue("equals", fieldIndex, subFieldIndex, matchValues);
 	}
 	
 	
-	public boolean doesSubFieldMatchValue(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
+	public boolean hasSubFieldMatchingValue(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.doesSubFieldMatchValue(matchType, subFieldIndex, matchValues);
+		return field.hasSubFieldMatchingValue(matchType, subFieldIndex, matchValues);
 	}
 	
 	

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -431,24 +431,24 @@ public class Segment extends MessageComponent implements Serializable {
 
 	
 	/**
-	 * Does any repetition of the field in this segment contain the supplied value.
+	 * Does any repetition of the field in this segment match the supplied value.
 	 * 
 	 * @param fieldIndex
 	 * @param value
 	 * @return
 	 * @throws Exception
 	 */
-	public boolean doesFieldContainValue(int fieldIndex, String value) throws Exception {
+	public boolean doesFieldMatchValue(int fieldIndex, String value) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.doesFieldContainValue(value);
+		return field.doesFieldMatchValue(value);
 	}
 
 	
-	public boolean doesSubFieldContainValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public boolean doesSubFieldMatchValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.doesSubFieldContainValue(subFieldIndex, value);
+		return field.doesSubFieldMatchValue(subFieldIndex, value);
 	}
 	
 	
@@ -518,47 +518,47 @@ public class Segment extends MessageComponent implements Serializable {
 
 
 	/**
-	 * Gets a Field repetition which contains the supplied value at the supplied sub field index.
+	 * Gets a Field repetition which matches the supplied value at the supplied sub field index.
 	 * 
 	 * @param fieldIndex
 	 * @param subFieldIndex
 	 * @param value
 	 * @return
 	 */
-	public FieldRepetition getFieldRepetitionContainingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public FieldRepetition getFieldRepetitionMatchingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.getRepetitionContainingValue(subFieldIndex, value);
+		return field.getRepetitionMatchingValue(subFieldIndex, value);
 	}
 	
 	
 	/**
-	 * Gets a Field repetition which contains the supplied value at the supplied sub field index.
+	 * Gets a Field repetition which matches the supplied value at the supplied sub field index.
 	 * 
 	 * @param fieldIndex
 	 * @param subFieldIndex
 	 * @param value
 	 * @return
 	 */
-	public List<FieldRepetition> getFieldRepetitionsContainingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
+	public List<FieldRepetition> getFieldRepetitionsMatchingValue(int fieldIndex, int subFieldIndex, String value) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.getRepetitionsContainingValue(subFieldIndex, value);
+		return field.getRepetitionsMatchingValue(subFieldIndex, value);
 	}
 
 	
 	/**
-	 * Gets a list of Field repetitions which do not contain the supplied value at the supplied sub field index.
+	 * Gets a list of Field repetitions which do not match the supplied value at the supplied sub field index.
 	 * 
 	 * @param fieldIndex
 	 * @param subFieldIndex
 	 * @param value
 	 * @return
 	 */
-	public List<FieldRepetition> getFieldRepetitionsNotContainingValue(int fieldIndex, int subFieldIndex, String ... values) throws Exception {
+	public List<FieldRepetition> getFieldRepetitionsNotMatchingValue(int fieldIndex, int subFieldIndex, String ... values) throws Exception {
 		Field field = getField(fieldIndex);
 		
-		return field.getRepetitionsNotContainingValue(subFieldIndex, values);
+		return field.getRepetitionsNotMatchingValue(subFieldIndex, values);
 	}
 	
 	


### PR DESCRIPTION
Rename methods and add a match type which can be either equals (the default), contains, starts-with or ends-with.