### PR TITLE
Allow attributes to be sent from the duplicate WUP to the f…

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/BaseMessageDuplication.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/BaseMessageDuplication.java
@@ -20,6 +20,7 @@ import net.fhirfactory.pegacorn.core.model.dataparcel.valuesets.PolicyEnforcemen
 import net.fhirfactory.pegacorn.core.model.petasos.uow.UoW;
 import net.fhirfactory.pegacorn.core.model.petasos.uow.UoWPayload;
 import net.fhirfactory.pegacorn.core.model.petasos.uow.UoWProcessingOutcomeEnum;
+import net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.message.transformation.HL7MessageWithAttributes;
 
 /**
  * Base class for all classes which need to duplicate a message.  The duplication rules are provided by the sub classes.
@@ -69,13 +70,16 @@ public abstract class BaseMessageDuplication {
 		}
 
 		uow.getEgressContent().getPayloadElements().clear();
+		
 
 		// Add a entry as a unit of work payload.
-		for (Message message : messages) {
+		for (int i = 0; i < messages.size(); i++) {				
+			HL7MessageWithAttributes messageAttributes = addDuplicationAttributes(messages, i);
+			
 			UoWPayload contentPayload = new UoWPayload();
 
 			contentPayload.setPayloadManifest(manifest);
-			contentPayload.setPayload(message.toString());
+			contentPayload.setPayload(messageAttributes.toString());
 
 			newUoW.getEgressContent().getPayloadElements().add(contentPayload);
 		}
@@ -96,4 +100,15 @@ public abstract class BaseMessageDuplication {
 	public abstract List<Message>createMessages(Message orginalMessage) throws Exception;
 	
 	public abstract Logger getLogger();
+	
+	/**
+	 * Add duplication message attributes.  The default implementation adds 
+	 * 
+	 * @param messages
+	 * @param currentMessageIndex
+	 * @return
+	 */
+	public HL7MessageWithAttributes addDuplicationAttributes(List<Message> messages, int currentMessageIndex) {
+		return new HL7MessageWithAttributes(messages.get(currentMessageIndex).toString());
+	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/message/transformation/FreeMarkerConfiguration.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/message/transformation/FreeMarkerConfiguration.java
@@ -8,6 +8,7 @@ import javax.enterprise.context.ApplicationScoped;
 
 import org.apache.camel.Exchange;
 import org.apache.camel.component.freemarker.FreemarkerConstants;
+import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,10 +44,26 @@ public class FreeMarkerConfiguration {
 	 * @throws HL7Exception
 	 * @throws IOException
 	 */
-	public void configure(UoW uow, Exchange exchange) throws HL7Exception, IOException {	
+	public void configure(UoW uow, Exchange exchange) throws HL7Exception, IOException, Exception {	
 		Message message = extractHL7Message(uow, exchange);
-		configure(uow, message, exchange);
+		configure(uow, message, exchange, null);
 	}
+	
+	
+	/**
+	 * Configure Freemarker.  The uow will contain a {@link HL7MessageWithAttributes}.  
+	 * 
+	 * @param uow
+	 * @param exchange
+	 * @throws HL7Exception
+	 * @throws IOException
+	 */
+	public void configureFromJSONWithAdditionalAttributes(UoW uow, Exchange exchange) throws HL7Exception, IOException, Exception {	
+		Message message = extractHL7MessageFromJSON(uow, exchange);
+		Map<String, Object> hl7MessageAttributes = extractHL7MessageAttrbutesFromJSON(uow, exchange);
+		configure(uow, message, exchange, hl7MessageAttributes);
+	}
+	
 	
 	
 	/**
@@ -57,34 +74,40 @@ public class FreeMarkerConfiguration {
 	 * @throws HL7Exception
 	 * @throws IOException
 	 */
-	public void configure(Message message, Exchange exchange) throws HL7Exception, IOException {
+	public void configure(Message message, Exchange exchange) throws HL7Exception, IOException, Exception {
 		PetasosFulfillmentTaskSharedInstance fulfillmentTask = (PetasosFulfillmentTaskSharedInstance) exchange.getProperty(PetasosPropertyConstants.WUP_PETASOS_FULFILLMENT_TASK_EXCHANGE_PROPERTY);
-		configure(fulfillmentTask.getTaskWorkItem(), message, exchange);
+		configure(fulfillmentTask.getTaskWorkItem(), message, exchange, null);
 	}
 
-        /**
-         * Configure Freemarker; add required data, methods which will be used inside freemarker transformation files (*.ftl).
-         *
-         * @param uoW the unit of work being transformed.
-         * @param message extracted message from the current unit of work.
-         * @param exchange the camel exchange.
-         */
-        private void configure(UoW uoW, Message message, Exchange exchange) {
-            Map<String, Object> variableMap = new HashMap<>();
-            variableMap.put("uoW", uoW);
-            variableMap.put("message", message);
-            variableMap.put("exchange", exchange);
-            // Set sendMessage property in the exchange to default of true, as is the case with most transformations, which require to be sent.
-            exchange.setProperty("sendMessage", true);
-            exchange.getIn().setHeader(FreemarkerConstants.FREEMARKER_DATA_MODEL, variableMap);
-            BeansWrapper wrapper = new BeansWrapper(new Version(2, 3, 27));
-            TemplateModel statics = wrapper.getStaticModels();
-
-            variableMap.put("statics", statics);
-        }
-	
 	
 	/**
+     * Configure Freemarker; add required data, methods which will be used inside freemarker transformation files (*.ftl).
+     *
+     * @param uoW the unit of work being transformed.
+     * @param message extracted message from the current unit of work.
+     * @param exchange the camel exchange.
+     */
+    private void configure(UoW uoW, Message message, Exchange exchange, Map<String, Object> hl7MessageAttributes) throws Exception {
+        Map<String, Object> variableMap = new HashMap<>();
+        variableMap.put("uoW", uoW);
+        variableMap.put("message", message);
+        variableMap.put("exchange", exchange);
+        // Set sendMessage property in the exchange to default of true, as is the case with most transformations, which require to be sent.
+        exchange.setProperty("sendMessage", true);
+        
+        if (hl7MessageAttributes != null) {
+        	variableMap.putAll(hl7MessageAttributes);
+        }
+        
+        exchange.getIn().setHeader(FreemarkerConstants.FREEMARKER_DATA_MODEL, variableMap);
+        BeansWrapper wrapper = new BeansWrapper(new Version(2, 3, 27));
+        TemplateModel statics = wrapper.getStaticModels();
+
+        variableMap.put("statics", statics);
+    }
+
+    
+    /**
 	 * Get the message out of the unit of work so it can be passed to Freemarker.
 	 * 
 	 * @param uow
@@ -102,8 +125,7 @@ public class FreeMarkerConfiguration {
 					
 			break;
 		}
-		
-		
+
 		// Maybe the message is on the ingres feed.
 		if (hl7Message == null) {
 			hl7Message = uow.getIngresContent().getPayload();
@@ -127,6 +149,57 @@ public class FreeMarkerConfiguration {
 
 			return parser.parse(hl7Message);
 		}
+	}
+	
+	
+	/**
+	 * Get the message out of the unit of work so it can be passed to Freemarker.
+	 * 
+	 * @param uow
+	 * @param exchange
+	 * @return
+	 * @throws IOException
+	 * @throws HL7Exception
+	 */
+	private Message extractHL7MessageFromJSON(UoW uow, Exchange exchange) throws IOException, HL7Exception, Exception {
+		return getHL7MessageWithAttributes(uow, exchange).getMessage();
+	}
+
+	
+	/**
+	 * Get the message out of the unit of work so it can be passed to Freemarker.
+	 * 
+	 * @param uow
+	 * @param exchange
+	 * @return
+	 * @throws IOException
+	 * @throws HL7Exception
+	 */
+	private Map<String, Object> extractHL7MessageAttrbutesFromJSON(UoW uow, Exchange exchange) throws IOException, HL7Exception, Exception {	
+		return getHL7MessageWithAttributes(uow, exchange).getAttributes();
+	}
+
+	
+	private HL7MessageWithAttributes getHL7MessageWithAttributes(UoW uow, Exchange exchange) {
+		String jsonMessageWithAttributes = null;
+
+		// get the first and only payload element.
+		for (UoWPayload payload : uow.getEgressContent().getPayloadElements()) {
+			jsonMessageWithAttributes = payload.getPayload();
+					
+			break;
+		}
+
+		// Maybe the message is on the ingres feed.
+		if (jsonMessageWithAttributes == null) {
+			jsonMessageWithAttributes = uow.getIngresContent().getPayload();
+		}
+		
+		if (jsonMessageWithAttributes == null) {
+			throw new RuntimeException("Unable to extract the HL7 message with attributes");
+		}
+		
+		return new HL7MessageWithAttributes(new JSONObject(jsonMessageWithAttributes));
 	}
 	
 	

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/message/transformation/HL7MessageWithAttributes.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/message/transformation/HL7MessageWithAttributes.java
@@ -1,0 +1,102 @@
+package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans.message.transformation;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+
+import ca.uhn.hl7v2.DefaultHapiContext;
+import ca.uhn.hl7v2.HapiContext;
+import ca.uhn.hl7v2.model.Message;
+import ca.uhn.hl7v2.parser.DefaultModelClassFactory;
+import ca.uhn.hl7v2.parser.ModelClassFactory;
+import ca.uhn.hl7v2.parser.PipeParser;
+
+/**
+ * HL7 Message + message attributes to be used in freemarker templates.
+ * 
+ * @author Brendan Douglas
+ *
+ */
+public class HL7MessageWithAttributes {
+	
+	private String message;
+	protected Map<String, Object> attributes = new HashMap<>();
+	
+	
+	public HL7MessageWithAttributes(String message) {
+		this.message = message;
+	}
+
+	
+	/**
+	 * Constructs this object from a json object.
+	 * 
+	 * @param messageWithAttributes
+	 */
+	public HL7MessageWithAttributes(JSONObject messageWithAttributes) {
+		
+		this.message = messageWithAttributes.getString("message");
+		
+		JSONArray jsonArray = messageWithAttributes.getJSONArray("attributes");
+		
+		for (int i = 0; i < jsonArray.length(); i++) {
+			JSONObject attribute = jsonArray.getJSONObject(i);
+			
+			
+			Iterator<String>iterator = attribute.keys();
+			
+			while(iterator.hasNext()) {
+				String keyValue = iterator.next();
+							
+				attributes.put(keyValue, attribute.get(keyValue));
+			}
+		}
+	}
+
+	
+	public void addAttribute(String key, Object value) {
+		attributes.put(key, value);
+	}
+
+	
+	@Override
+	public String toString() {
+		JSONObject jsonObject = new JSONObject();
+		
+		jsonObject.put("message", message);
+		
+		JSONArray jsonAttributeArray = new JSONArray();
+		
+		for (Map.Entry<String, Object> entry : attributes.entrySet()) {
+			JSONObject attribute = new JSONObject();
+			attribute.put(entry.getKey(), entry.getValue());
+			jsonAttributeArray.put(attribute);
+		}
+		
+		jsonObject.put("attributes", jsonAttributeArray);
+
+		return jsonObject.toString();
+	}
+	
+	
+	public Message getMessage() throws Exception {
+		try (HapiContext hapiContext = new DefaultHapiContext();) {
+			PipeParser parser = hapiContext.getPipeParser();
+			parser.getParserConfiguration().setValidating(false);
+
+			ModelClassFactory cmf = new DefaultModelClassFactory();
+			hapiContext.setModelClassFactory(cmf);
+
+			Message message = parser.parse(this.message);
+			return message;
+		}
+	}
+	
+	
+	public  Map<String, Object> getAttributes() {
+		return attributes;
+	}
+}


### PR DESCRIPTION
The ORU messages get duplicated and each duplicate needs to access a different ZPF-4 repetition.  To know what repetition to access a change has been made to allow attributes to be sent from the duplication code to the transformations.  The payload is now a JSON object which contains the HL7Message and a list of attributes.

Freemarker can now be configured two ways.  1) The uow has the message (as a string) as the payload. 2) The uow has a JSON object which contains the message and the attributes.