### PR TITLE
 Duplicate message change and remove notMatching methods

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/message/transformation/HL7MessageWithAttributes.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/message/transformation/HL7MessageWithAttributes.java
@@ -99,4 +99,14 @@ public class HL7MessageWithAttributes {
 	public  Map<String, Object> getAttributes() {
 		return attributes;
 	}
+	
+	
+	public Object getAttribute(String key) {
+		return attributes.get(key);
+	}
+	
+	
+	public void setMessage(Message message) {
+		this.message = message.toString();
+	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -679,33 +679,8 @@ public class Field extends MessageComponent implements Serializable {
 		List<FieldRepetition> fieldRepetitions = this.getRepetitionsMatchingValue(matchType, subFieldIndex, matchValues);
 		this.repetitions.removeAll(fieldRepetitions);
 	}
-
 	
-	/**
-	 * Removes field repetitions where the matchValue does not match the subField value.
-	 * 
-	 * @param subFieldIndex
-	 * @param matchValue
-	 * @throws Exception
-	 */
-	public void removeNotMatchingFieldRepetitions(int subFieldIndex, String ... matchValues) throws Exception {	
-		removeNotMatchingFieldRepetitions("equals", subFieldIndex, matchValues);
-	}
 	
-
-	/**
-	 * Removes field repetitions where the matchValue does not match the subField value.
-	 * 
-	 * @param subFieldIndex
-	 * @param matchValue
-	 * @throws Exception
-	 */
-	public void removeNotMatchingFieldRepetitions(String matchType, int subFieldIndex, String ... matchValues) throws Exception {	
-		List<FieldRepetition>fieldRepetitions = this.getRepetitionsNotMatchingValue(matchType, subFieldIndex, matchValues);
-		this.repetitions.removeAll(fieldRepetitions);
-	}
-
-
 	/**
 	 * Sets a subField value in all repetitions.
 	 * 
@@ -792,43 +767,6 @@ public class Field extends MessageComponent implements Serializable {
 	public List<FieldRepetition> getRepetitionsMatchingValue(int subFieldIndex, String ... matchValues) throws Exception {
 		return getRepetitionsMatchingValue("equals", subFieldIndex, matchValues);
 	}
-
-	
-	/**
-	 * Returns a list of Field repetitions of this field not Matching one of the supplied value at the supplied sub field index.
-	 * 
-	 * @param subFieldIndex
-	 * @param value
-	 * @return
-	 * @throws Exception
-	 */
-	public List<FieldRepetition> getRepetitionsNotMatchingValue(String matchType, int subFieldIndex, String ... matchValues) throws Exception {
-		List<FieldRepetition>fieldRepetitions = new ArrayList<>();
-		
-	
-		for (FieldRepetition repetition : getRepetitions()) {
-			Subfield subField = repetition.getSubField(subFieldIndex);
-
-			if (!compare(matchType, subField.value(), matchValues)) {
-				fieldRepetitions.add(repetition);
-			}
-		}
-		
-		return fieldRepetitions;
-	}
-	
-	
-	/**
-	 * Returns a list of Field repetitions of this field not Matching one of the supplied value at the supplied sub field index.
-	 * 
-	 * @param subFieldIndex
-	 * @param value
-	 * @return
-	 * @throws Exception
-	 */
-	public List<FieldRepetition> getRepetitionsNotMatchingValue(int subFieldIndex, String ... matchValues) throws Exception {
-		return getRepetitionsNotMatchingValue("equals", subFieldIndex, matchValues);
-	}
 	
 	
 	/**
@@ -842,27 +780,51 @@ public class Field extends MessageComponent implements Serializable {
 	private boolean compare(String matchType, String text, String ... matchValues) {
 		MatchTypeEnum type = MatchTypeEnum.get(matchType);
 		
+		boolean result = false;
+		if (matchType.toLowerCase().startsWith("not")) {
+			result = true;
+		}
+		
 		
 		for (String matchValue : matchValues) {
-		
+				
 			switch (type) {
 				case EQUALS:
 					if  (text.equals(matchValue)) {
-						return true;
+						result = true;
 					}
 					break;
 				case CONTAINS:
 					if (text.contains(matchValue)) {
-						return true;
+						result = true;
 					}
 				case ENDS_WITH:
 					if (text.endsWith(matchValue)) {
-						return true;
+						result = true;
 					}
 					break;
 				case STARTS_WITH:
 					if (text.startsWith(matchValue)) {
-						return true;
+						result = true;
+					}
+					break;
+				case NOT_ENDS_WITH:
+					if (text.endsWith(matchValue)) {
+						result = false;
+					}
+					break;
+				case NOT_CONTAINS:
+					if (text.contains(matchValue)) {
+						result = false;
+					}
+				case NOT_STARTS_WITH:
+					if (text.startsWith(matchValue)) {
+						result = false;
+					}
+					break;
+				case NOT_EQUALS:
+					if  (text.equals(matchValue)) {
+						result = false;
 					}
 					break;
 				default:
@@ -872,6 +834,6 @@ public class Field extends MessageComponent implements Serializable {
 			}
 		}
 		
-		return false;
+		return result;
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -980,38 +980,6 @@ public class HL7Message implements Serializable   {
 	
 	
 	/**
-	 * Removes a field repetitions.
-	 * 
-	 * @param segmentName
-	 * @param fieldIndex
-	 * @param subFieldIndex
-	 * @param matchValue
-	 * @throws Exception
-	 */
-	public void removeNotMatchingFieldRepetitions(String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		removeNotMatchingFieldRepetitions("equals", segmentName, fieldIndex, subFieldIndex, matchValues);
-	}
-	
-	
-	/**
-	 * Removes field repetitions.
-	 * 
-	 * @param matchType
-	 * @param segmentName
-	 * @param fieldIndex
-	 * @param subFieldIndex
-	 * @param matchValue
-	 * @throws Exception
-	 */
-	public void removeNotMatchingFieldRepetitions(String matchType, String segmentName, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		for (Segment segment : this.getSegments(segmentName)) {
-			segment.removeNotMatchingFieldRepetitions(matchType, fieldIndex, subFieldIndex, matchValues);
-		}
-	}
-		
-	
-	
-	/**
 	 * Returns a segment.
 	 * 
 	 * @param segmentName

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MatchTypeEnum.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/MatchTypeEnum.java
@@ -10,7 +10,11 @@ public enum MatchTypeEnum {
 	EQUALS("equals"),
 	CONTAINS("contains"),
 	STARTS_WITH("starts-with"),
-	ENDS_WITH("ends-with");
+	ENDS_WITH("ends-with"),
+	NOT_EQUALS("not-equals"),
+	NOT_CONTAINS("not-contains"),
+	NOT_STARTS_WITH("not-starts-with"),
+	NOT_ENDS_WITH("not-ends-with");
 	
 	private String type;
 	

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/PIDSegment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/PIDSegment.java
@@ -75,6 +75,6 @@ public class PIDSegment extends Segment implements Serializable {
 	 * @throws Exception
 	 */
 	public void removeOtherPatientIdentifierFields( String identifierToKeep) throws Exception  {	
-		removeNotMatchingFieldRepetitions(3,5, identifierToKeep);
+		removeMatchingFieldRepetitions("not-equals", 3,5, identifierToKeep);
 	}
 }

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Segment.java
@@ -519,35 +519,8 @@ public class Segment extends MessageComponent implements Serializable {
 		
 		field.removeMatchingFieldRepetitions(matchType, subFieldIndex, matchValues);	
 	}
-
-
-	/**
-	 * Removes field repetitions which do not match one of the supplied values.
-	 * 
-	 * @param fieldIndex
-	 * @param subFieldIndex
-	 * @param matchValue
-	 * @throws Exception
-	 */
-	public void removeNotMatchingFieldRepetitions(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		removeNotMatchingFieldRepetitions("equals", fieldIndex, subFieldIndex, matchValues);
-	}
 	
 	
-	/**
-	 * Removes field repetitions which do not match one of the supplied values.
-	 * 
-	 * @param fieldIndex
-	 * @param subFieldIndex
-	 * @param matchValue
-	 * @throws Exception
-	 */
-	public void removeNotMatchingFieldRepetitions(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		Field field = this.getField(fieldIndex);
-		field.removeNotMatchingFieldRepetitions(matchType, subFieldIndex, matchValues);
-	}
-
-
 	/**
 	 * Sets the same value in all subFields
 	 * 
@@ -615,34 +588,6 @@ public class Segment extends MessageComponent implements Serializable {
 		Field field = getField(fieldIndex);
 		
 		return field.getRepetitionsMatchingValue(matchType, subFieldIndex, matchValues);
-	}
-
-	
-	/**
-	 * Gets a list of Field repetitions which do not match the supplied value at the supplied sub field index.
-	 * 
-	 * @param fieldIndex
-	 * @param subFieldIndex
-	 * @param value
-	 * @return
-	 */
-	public List<FieldRepetition> getFieldRepetitionsNotMatchingValue(int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		return getFieldRepetitionsNotMatchingValue("equals", fieldIndex, subFieldIndex, matchValues);
-	}
-	
-	
-	/**
-	 * Gets a list of Field repetitions which do not match the supplied value at the supplied sub field index.
-	 * 
-	 * @param fieldIndex
-	 * @param subFieldIndex
-	 * @param value
-	 * @return
-	 */
-	public List<FieldRepetition> getFieldRepetitionsNotMatchingValue(String matchType, int fieldIndex, int subFieldIndex, String ... matchValues) throws Exception {
-		Field field = getField(fieldIndex);
-		
-		return field.getRepetitionsNotMatchingValue(matchType, subFieldIndex, matchValues);
 	}
 	
 	


### PR DESCRIPTION
1) Simplify duplicate message code.

2) remove notMatching methods and allow add not conditions to the match type enum.