### PR TITLE
#264139 - Add methods to return an empty segment, field and field reptition

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/Field.java
@@ -21,6 +21,8 @@ public class Field extends MessageComponent implements Serializable {
 	
 	private Segment segment = null;
 	
+	protected Field() {}
+	
 	public Field(String field, boolean handleSeperators, Segment segment) {
 		this.segment = segment;
 		

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/FieldRepetition.java
@@ -20,6 +20,8 @@ public class FieldRepetition extends MessageComponent implements Serializable  {
 	private List<Subfield>subFields = new ArrayList<>();
 	private Field field = null;
 	
+	protected FieldRepetition() {}
+	
 	public FieldRepetition(String fieldRepetition, boolean handleSeperators, Field field) {
 		this.field = field;
 		
@@ -49,6 +51,7 @@ public class FieldRepetition extends MessageComponent implements Serializable  {
 	}
 	
 	
+	@Override
 	public String toString() {		
 		return subFields.stream().map(Subfield::toString).collect(Collectors.joining("^"));
 	}
@@ -89,6 +92,7 @@ public class FieldRepetition extends MessageComponent implements Serializable  {
 	 * 
 	 * @throws Exception
 	 */
+	@Override
 	public void clear() throws Exception {
 		setValue("");
 	}
@@ -98,6 +102,7 @@ public class FieldRepetition extends MessageComponent implements Serializable  {
 	}	
 	
 	
+	@Override
 	public String value() {
 		return toString();
 	}
@@ -148,6 +153,7 @@ public class FieldRepetition extends MessageComponent implements Serializable  {
 	 * @param value
 	 * @throws Exception
 	 */
+	@Override
 	public void setValue(String value) throws Exception {
 		subFields.clear();
 			

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/transformation/model/HL7Message.java
@@ -1191,4 +1191,40 @@ public class HL7Message implements Serializable   {
 		
 		return segment;
 	}
+	
+	
+	/**
+	 * Returns an empty segment.  The segment is not added to the message.
+	 * 
+	 * @param segmentName
+	 * @return
+	 * @throws Exception
+	 */
+	public Segment createEmptySegment(String segmentName) throws Exception {
+		return new Segment(segmentName, this);
+	}
+	
+	
+	/**
+	 * Returns an empty field repetition.  The field repetition is not added to the message.
+	 * 
+	 * @param segmentName
+	 * @return
+	 * @throws Exception
+	 */
+	public FieldRepetition createEmptyFieldRepetition() throws Exception {
+		return new FieldRepetition();
+	}
+	
+	
+	/**
+	 * Returns an empty field.  The field is not added to the message.
+	 * 
+	 * @param segmentName
+	 * @return
+	 * @throws Exception
+	 */
+	public Field createEmptyField() throws Exception {
+		return new Field();
+	}	
 }


### PR DESCRIPTION
A change to create and return empty message elements (segment, field and field repetitions).