### PR TITLE
#274967 - Change method signature to a String

### DIFF
--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/HL7v2xInboundMessageTransformationPostProcessor.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/HL7v2xInboundMessageTransformationPostProcessor.java
@@ -21,8 +21,14 @@
  */
 package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans;
 
-import ca.uhn.hl7v2.model.Message;
-import net.fhirfactory.pegacorn.internals.hl7v2.interfaces.HL7v2xInformationExtractionInterface;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.apache.camel.Exchange;
+import org.apache.commons.lang3.SerializationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.fhirfactory.pegacorn.core.constants.petasos.PetasosPropertyConstants;
 import net.fhirfactory.pegacorn.core.model.dataparcel.DataParcelManifest;
 import net.fhirfactory.pegacorn.core.model.dataparcel.DataParcelTypeDescriptor;
@@ -34,14 +40,8 @@ import net.fhirfactory.pegacorn.core.model.petasos.uow.UoW;
 import net.fhirfactory.pegacorn.core.model.petasos.uow.UoWPayload;
 import net.fhirfactory.pegacorn.core.model.petasos.uow.UoWProcessingOutcomeEnum;
 import net.fhirfactory.pegacorn.internals.fhir.r4.internal.topics.HL7V2XTopicFactory;
+import net.fhirfactory.pegacorn.internals.hl7v2.interfaces.HL7v2xInformationExtractionInterface;
 import net.fhirfactory.pegacorn.petasos.core.tasks.accessors.PetasosFulfillmentTaskSharedInstance;
-import org.apache.camel.Exchange;
-import org.apache.commons.lang3.SerializationUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 /**
  * Transforms a HL7 message
@@ -81,7 +81,7 @@ public class HL7v2xInboundMessageTransformationPostProcessor {
      * @param exchange
      * @param message
      */
-    public UoW postTransformProcessing(Message message, Exchange exchange) {
+    public UoW postTransformProcessing(String message, Exchange exchange) {
         getLogger().debug(".postTransformProcessing(): Entry, message->{}", message);
         //
         // We embed the fulfillmentTask within the exchange as part of Petasos framework

--- a/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/HL7v2xOutboundMessageTransformationPostProcessor.java
+++ b/pegacorn-mitaf-hl7v2-platform/src/main/java/net/fhirfactory/pegacorn/mitaf/hl7/v2x/workshops/transform/beans/HL7v2xOutboundMessageTransformationPostProcessor.java
@@ -21,8 +21,14 @@
  */
 package net.fhirfactory.pegacorn.mitaf.hl7.v2x.workshops.transform.beans;
 
-import ca.uhn.hl7v2.model.Message;
-import net.fhirfactory.pegacorn.internals.hl7v2.interfaces.HL7v2xInformationExtractionInterface;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+
+import org.apache.camel.Exchange;
+import org.apache.commons.lang3.SerializationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import net.fhirfactory.pegacorn.core.constants.petasos.PetasosPropertyConstants;
 import net.fhirfactory.pegacorn.core.model.dataparcel.DataParcelManifest;
 import net.fhirfactory.pegacorn.core.model.dataparcel.DataParcelTypeDescriptor;
@@ -34,14 +40,8 @@ import net.fhirfactory.pegacorn.core.model.petasos.uow.UoW;
 import net.fhirfactory.pegacorn.core.model.petasos.uow.UoWPayload;
 import net.fhirfactory.pegacorn.core.model.petasos.uow.UoWProcessingOutcomeEnum;
 import net.fhirfactory.pegacorn.internals.fhir.r4.internal.topics.HL7V2XTopicFactory;
+import net.fhirfactory.pegacorn.internals.hl7v2.interfaces.HL7v2xInformationExtractionInterface;
 import net.fhirfactory.pegacorn.petasos.core.tasks.accessors.PetasosFulfillmentTaskSharedInstance;
-import org.apache.camel.Exchange;
-import org.apache.commons.lang3.SerializationUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
 
 /**
  * Transforms a HL7 message
@@ -81,7 +81,7 @@ public class HL7v2xOutboundMessageTransformationPostProcessor {
      * @param exchange
      * @param message
      */
-    public UoW postTransformProcessing(Message message, Exchange exchange) {
+    public UoW postTransformProcessing(String message, Exchange exchange) {
         getLogger().debug(".postTransformProcessing(): Entry, message->{}", message);
         //
         // We embed the fulfillmentTask within the exchange as part of Petasos framework


### PR DESCRIPTION
Camel was converting the String returned from the transformations to a Message object and the parser Camel uses was resulting in formatting changes eg. leading spaces being removed